### PR TITLE
:sparkles: add improve-harness skill (SP3, knowledge loop apply side)

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -47,6 +47,7 @@
 
 - loop-mode = dev-cycle agent が spec (`rules/spec-contract.md` を満たす work item) を起点に自律実行する mode。人間の承認手続きを各工程の機械的 policy に置換する
 - 例外として許可: `commit-push-branch` (loop-mode 拡張) 経由の feature branch push + **draft PR 作成**
+- improve-harness (knowledge loop) も同例外を使える: harness 改善の draft PR 作成まで (対象 repo は dotfiles のみ)
 - 引き続き禁止: merge / draft の本 PR 化 / main への直 push / 新規 dependency 追加 / 破壊的操作 / 外部送信の有効化 — 検出したら escalation (ticket コメント + 通知 + WIP branch push) して停止
 - 安全装置 (hooks / permission deny / least privilege) は loop-mode でも一切緩めない
 - superpowers 棲み分け: 自律 pipeline (dev loop) では superpowers の process skill を使わない (背骨は自前 skill)。対話 session での brainstorming / TDD 参照は可

--- a/claude/ja/skills/improve-harness/SKILL.md
+++ b/claude/ja/skills/improve-harness/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: improve-harness
+description: 全 project の未処理 insights を集約し、現状照合 → 反映先判定 (memory → rules → skill → agent) → 改善実装 → dotfiles への改善 draft PR まで行う knowledge loop の反映側 skill。「improve-harness して」「harness 改善して」「insights 集約して」等で使う。設計判断はしない (undecided は要判断一覧で人間へ)。収集側は retrospect (対の skill)。
+---
+
+# improve-harness
+
+knowledge loop の反映側。retrospect が蓄積した insights を集約し、harness (skills / agents / rules / CLAUDE.md) への改善を draft PR として出す。
+**設計判断はしない** — 複数案併記・undecided な proposal は実装せず人間に返す。
+
+## 適用条件
+
+- 手動起動 (定期化は SP4 以降)
+- 対象 harness repo = dotfiles。cwd が dotfiles でない場合は dotfiles を対象に作業する
+
+## 手順
+
+### Step 1: 収集
+
+- `~/.claude/projects/*/insights/*.md` を全 project 横断で列挙する
+- frontmatter に `status:` がある file は処理済みとして除外する (未処理 = `status` なし)
+- 未処理 0 件なら「該当なし」と明示して正常終了する
+
+### Step 2: routing (機械的判定)
+
+frontmatter の `target` で振り分ける:
+
+| target | 扱い |
+|---|---|
+| harness 内 (`claude/` 配下 / `CLAUDE.md` / `rules/`) | 改善対象 → Step 3 へ |
+| harness 外 (他 repo のファイル / Claude Code 本体の挙動 / design doc・plans) | PR に含めない。「対象外報告」に回し、対象 project 側での対応提案を 1 行付けて `status: deferred` (reason: out-of-scope) |
+
+### Step 3: 現状照合
+
+- 各 insight の target file の**現状**を Read し、proposal が既に反映済みか判定する (手動先行適用があり得る)
+- 反映済み → frontmatter に `status: applied` を追記して除外する
+- この照合を skip して差分を作らない (重複適用・既存記述との逆行の防止)
+
+### Step 4: クラスタリング + 反映先判定
+
+- 関連する insight をまとめて 1 改善単位 (cluster) にする
+- 反映先は `references/promotion.md` の基準で判定する。**memory → rules → skill → agent の昇格順**で、変更コストの小さい側に倒す
+- `target` が明記された insight はそれに従う (昇格判定は target 不明・横断パターンの時のみ)
+- **memory 反映は PR 不要**: 対象 project の memory に直接 write し、報告のみ
+
+### Step 5: 改善実装
+
+- ja SoT (`claude/ja/...`) を編集 → en mirror (`claude/...`) は opus subagent へ翻訳委譲する (docs = opus 規約)。mirror を持たないファイル (`rules/` / `CLAUDE.md`) は単一編集
+- proposal が undecided / user 判断を要する (複数案併記・status 体系への介入・外部 account・権限拡大 等) → 実装せず `status: deferred` (reason 付き) で「要判断一覧」へ
+
+### Step 6: ship (draft PR)
+
+- `commit-push-branch` skill を **loop-mode 明示**で呼ぶ: branch 作成 + cluster ごとの commit + push + draft PR 作成
+- PR body: insight (file 名) ↔ 変更の対応表 + 要判断一覧
+- 根拠: CLAUDE.md「loop-mode」の例外規定 (improve-harness の harness 改善 draft PR)
+
+### Step 7: 状態更新 + 報告
+
+- PR に含めた insight: frontmatter に `status: proposed` + `pr: <URL>` を追記する
+- **全 insight の処遇表を強制出力する** (黙った skip 禁止):
+
+```
+## improve-harness 結果
+
+| insight | 処遇 | 反映先 / 理由 |
+|---|---|---|
+| 20260714-work-intake-skip-idempotency.md | proposed | work-intake references (PR #NN) |
+| 20260713-ready-flag-dual-representation.md | applied | 反映済み確認 (rules/spec-contract.md) |
+| 20260714-atlas-migrate-lint-pro-gated.md | deferred | 対象外 (他 repo)。対象 project 側での ticket 化を提案 |
+
+## 要判断 (人間へ)
+- <undecided な proposal の要約 + 判断してほしい点>
+```
+
+## status lifecycle (insight frontmatter)
+
+| status | 意味 |
+|---|---|
+| (なし) | 未処理 |
+| `applied` | 既反映を照合で確認 (PR 不要) |
+| `proposed` | 改善 draft PR に含めた (`pr:` 併記) |
+| `deferred` | 要判断・対象外・別 work 割当 (`reason:` 併記) |
+
+## 補助入力 (optional)
+
+session JSONL の集計 (観点 skip 傾向・token 消費等) は user が明示要求した時のみ実施する (`claude-session-jsonl` skill の recipe を使う)。default 入力は insights のみ。
+
+## 障害時
+
+- dotfiles に無関係な未 commit 変更がある場合: 触らず、改善 commit に含めない (明示 add — commit-push-branch の規約)
+- push / draft PR 作成が deny された場合: local commit まで保全し、branch 名を報告して停止する
+
+## 鉄則
+
+1. **全 insight の処遇を表で強制出力** — 黙った skip 禁止
+2. **draft PR まで** — merge / 本 PR 化 / master 直 push はしない
+3. **設計判断をしない** — 複数案・undecided は deferred で人間へ
+4. **PUBLIC repo の PR に内部情報を書かない** — 内部 URL / ticket 本文を転記しない。insight は file 名で参照する
+5. **insights 原本の本文を書き換えない** — frontmatter への status 追記のみ (本文は retrospect の成果物)
+6. **現状照合を skip しない** — 既反映の insight から差分を作らない

--- a/claude/ja/skills/improve-harness/references/promotion.md
+++ b/claude/ja/skills/improve-harness/references/promotion.md
@@ -1,0 +1,25 @@
+# 反映先の昇格基準 (memory → rules → skill → agent)
+
+improve-harness Step 4 の判定基準。**変更コストの小さい順に検討し、最初に条件を満たした先へ反映する** (design doc §5 の昇格原則)。
+`target` が明記された insight はこの表より優先してそれに従う。
+
+| 反映先 | 条件 (これで足りるなら昇格しない) | 例 | 変更手段 |
+|---|---|---|---|
+| memory | project 固有の事実・環境の癖で、手順化するほどの一般性がない。次 session が知っていれば十分 | 「repo X は ja が SoT」/ deny された command の代替 recipe | 対象 project の memory に直接 write (PR 不要) |
+| rules/ | repo 横断の行動原則・contract の 1-2 行規範。どの skill / agent からも参照され得る | ready flag の SoT 規定 / 検証原則への追記 | dotfiles PR (ja 単一、mirror なし) |
+| skill | 特定 skill の手順・checklist・発火条件の gap。再現性を手順として固定したい | work-intake の skip idempotency / retrospect の記録先規定 | dotfiles PR (ja SoT + en mirror) |
+| agent | agent 定義の挙動・model routing・tool 制約の規定 | dev-cycle の worktree 自己回復規定 | dotfiles PR (ja SoT + en mirror) |
+
+## 判定の目安
+
+- **一般性**: 1 project 限り → memory。repo 横断 → rules 以上
+- **形**: 事実の記憶で足りる → memory。原則 1-2 行 → rules。手順・checklist が要る → skill / agent
+- **強制力**: 「知っていれば良い」→ memory / rules。「必ずこの手順で実行」→ skill / agent
+- 迷ったら小さい側へ。skill への焼き付けは同種 insight が 2 件以上溜まってからでも遅くない
+
+## アンチパターン
+
+- 1 回きりの事象を skill の恒久手順に焼き付ける (rot の元)
+- memory で足りる内容を rules/ に書いて全 session の context を太らせる
+- 同じ規範を複数 skill に重複記載する (rules/ に 1 箇所書いて参照させる)
+- 昇格判定を理由に proposal を書き換える (内容の再設計は人間の領分)

--- a/claude/skills/improve-harness/SKILL.md
+++ b/claude/skills/improve-harness/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: improve-harness
+description: The apply side of the knowledge loop — aggregates unprocessed insights across all projects, then reconciles against current state → decides where to apply (memory → rules → skill → agent) → implements the improvement → all the way to a draft improvement PR against dotfiles. Use for "improve-harness して" ("run improve-harness"), "harness 改善して" ("improve the harness"), "insights 集約して" ("aggregate the insights"), etc. Makes no design decisions (undecided items go back to a human as a decisions-needed list). The collection side is retrospect (its paired skill).
+---
+
+> **Source of truth:** `claude/ja/skills/improve-harness/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# improve-harness
+
+The apply side of the knowledge loop. Aggregates the insights retrospect has accumulated and ships harness (skills / agents / rules / CLAUDE.md) improvements as a draft PR.
+**Makes no design decisions** — proposals that list multiple options or are undecided are not implemented; they go back to a human.
+
+## Applicability
+
+- Manual launch (scheduling comes in SP4 and later)
+- Target harness repo = dotfiles. If cwd is not dotfiles, work against dotfiles as the target
+
+## Procedure
+
+### Step 1: Collect
+
+- Enumerate `~/.claude/projects/*/insights/*.md` across all projects
+- Files whose frontmatter has `status:` are already processed and excluded (unprocessed = no `status`)
+- If there are 0 unprocessed, state "none applicable" explicitly and exit normally
+
+### Step 2: Routing (mechanical decision)
+
+Sort by the `target` in the frontmatter:
+
+| target | handling |
+|---|---|
+| inside the harness (`claude/` subtree / `CLAUDE.md` / `rules/`) | improvement target → proceed to Step 3 |
+| outside the harness (files in other repos / Claude Code's own behavior / design docs / plans) | not included in the PR. Route to the "out-of-scope report", attach a one-line proposal for handling it on the target project's side, and set `status: deferred` (reason: out-of-scope) |
+
+### Step 3: Reconcile against current state
+
+- Read the **current state** of each insight's target file and decide whether the proposal is already applied (manual pre-application is possible)
+- Already applied → add `status: applied` to the frontmatter and exclude it
+- Do not skip this reconciliation and produce a diff anyway (prevents duplicate application and regressions against existing text)
+
+### Step 4: Clustering + deciding where to apply
+
+- Group related insights into a single improvement unit (cluster)
+- Decide where to apply using the criteria in `references/promotion.md`. Following the **promotion order memory → rules → skill → agent**, fall to the side with the smaller change cost
+- An insight with an explicit `target` follows it (promotion decision applies only when the target is unclear or the pattern is cross-cutting)
+- **Applying to memory needs no PR**: write directly to the target project's memory and just report it
+
+### Step 5: Implement the improvement
+
+- Edit the ja SoT (`claude/ja/...`) → delegate the en mirror (`claude/...`) translation to an opus subagent (docs = opus convention). Files with no mirror (`rules/` / `CLAUDE.md`) are edited in a single place
+- If the proposal is undecided / requires user judgment (multiple options listed / intervention in the status scheme / external accounts / privilege escalation, etc.) → do not implement; set `status: deferred` (with reason) and add it to the "decisions-needed list"
+
+### Step 6: Ship (draft PR)
+
+- Call the `commit-push-branch` skill **with loop-mode explicitly set**: create the branch + one commit per cluster + push + create a draft PR
+- PR body: a mapping table of insight (file name) ↔ change + the decisions-needed list
+- Basis: the exception clause in CLAUDE.md "loop-mode" (improve-harness's harness-improvement draft PR)
+
+### Step 7: Update state + report
+
+- Insights included in the PR: add `status: proposed` + `pr: <URL>` to the frontmatter
+- **Force-output a disposition table for every insight** (no silent skips):
+
+```
+## improve-harness results
+
+| insight | disposition | applied to / reason |
+|---|---|---|
+| 20260714-work-intake-skip-idempotency.md | proposed | work-intake references (PR #NN) |
+| 20260713-ready-flag-dual-representation.md | applied | confirmed already applied (rules/spec-contract.md) |
+| 20260714-atlas-migrate-lint-pro-gated.md | deferred | out-of-scope (other repo). Proposed ticketing it on the target project's side |
+
+## Decisions needed (for a human)
+- <summary of the undecided proposal + the point you want decided>
+```
+
+## status lifecycle (insight frontmatter)
+
+| status | meaning |
+|---|---|
+| (none) | unprocessed |
+| `applied` | already-applied, confirmed by reconciliation (no PR) |
+| `proposed` | included in an improvement draft PR (`pr:` alongside) |
+| `deferred` | decision-needed / out-of-scope / assigned to separate work (`reason:` alongside) |
+
+## Auxiliary input (optional)
+
+Session JSONL aggregation (perspective-skip tendencies / token consumption, etc.) is done only when the user explicitly requests it (use the recipe in the `claude-session-jsonl` skill). The default input is insights only.
+
+## On failure
+
+- If dotfiles has unrelated uncommitted changes: leave them untouched and do not include them in the improvement commit (explicit add — commit-push-branch's convention)
+- If push / draft PR creation is denied: preserve up to the local commit, report the branch name, and stop
+
+## Iron rules
+
+1. **Force-output the disposition of every insight in a table** — no silent skips
+2. **Only up to a draft PR** — do not merge / promote out of draft / push directly to master
+3. **Make no design decisions** — multiple options / undecided go to a human as deferred
+4. **Do not write internal information into the PR of a PUBLIC repo** — do not transcribe internal URLs / ticket bodies. Reference insights by file name
+5. **Do not rewrite the body of the original insights** — only append status to the frontmatter (the body is retrospect's artifact)
+6. **Do not skip reconciliation against current state** — do not produce a diff from an already-applied insight

--- a/claude/skills/improve-harness/references/promotion.md
+++ b/claude/skills/improve-harness/references/promotion.md
@@ -1,0 +1,27 @@
+# Promotion criteria for where to apply (memory → rules → skill → agent)
+
+> **Source of truth:** `claude/ja/skills/improve-harness/references/promotion.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+The decision criteria for improve-harness Step 4. **Consider in ascending order of change cost, and apply to the first target whose condition is met** (the promotion principle in design doc §5).
+An insight with an explicit `target` takes precedence over this table and follows it.
+
+| apply to | condition (do not promote if this suffices) | example | means of change |
+|---|---|---|---|
+| memory | a project-specific fact / environment quirk with no generality worth turning into a procedure. Enough if the next session knows it | "repo X has ja as SoT" / an alternative recipe for a denied command | write directly to the target project's memory (no PR) |
+| rules/ | a 1-2 line norm for a cross-repo behavior principle / contract. May be referenced from any skill / agent | the SoT rule for the ready flag / an addition to a verification principle | dotfiles PR (ja only, no mirror) |
+| skill | a gap in a specific skill's procedure / checklist / trigger condition. You want to fix reproducibility as a procedure | work-intake's skip idempotency / retrospect's recording-destination rule | dotfiles PR (ja SoT + en mirror) |
+| agent | a rule about an agent definition's behavior / model routing / tool constraints | dev-cycle's worktree self-recovery rule | dotfiles PR (ja SoT + en mirror) |
+
+## Rules of thumb for deciding
+
+- **Generality**: limited to 1 project → memory. Cross-repo → rules or above
+- **Form**: remembering a fact suffices → memory. A 1-2 line principle → rules. A procedure / checklist is needed → skill / agent
+- **Enforcement**: "good enough to just know it" → memory / rules. "must always execute via this procedure" → skill / agent
+- When in doubt, fall to the smaller side. Baking into a skill is not too late even after 2 or more insights of the same kind have accumulated
+
+## Anti-patterns
+
+- Baking a one-off event into a skill's permanent procedure (a source of rot)
+- Writing content that memory would suffice for into rules/ and bloating every session's context
+- Duplicating the same norm across multiple skills (write it in one place in rules/ and reference it)
+- Rewriting a proposal on the grounds of the promotion decision (redesigning content is a human's domain)


### PR DESCRIPTION
## Summary
- add `improve-harness` skill (ja SoT + en mirror): aggregate unprocessed insights across projects → route (harness / out-of-scope) → reconcile against current state → promotion decision (memory → rules → skill → agent, `references/promotion.md`) → implement → draft PR via commit-push-branch loop-mode
- introduce insight processed-state tracking via frontmatter `status:` (`applied` / `proposed` / `deferred`; absent = unprocessed)
- extend CLAUDE.md loop-mode exception so improve-harness may create harness-improvement draft PRs (dotfiles only)

## Validation (SP3 DoD)
- to be run in a fresh session: one real run over accumulated insights must produce an improvement draft PR (validation principle #12: implementer / validator session separation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)