### PR TITLE
improve-harness: work-intake skip idempotency + dev-cycle worktree recovery

### DIFF
--- a/claude/agents/dev-cycle.md
+++ b/claude/agents/dev-cycle.md
@@ -102,7 +102,7 @@ If the plan includes a new service / new RPC / new enum / new ACL model / new AD
 
 **Before starting implementation, isolate with `EnterWorktree`** (implements design doc §7 row 4 "isolate via git worktree"; common to loop-mode and interactive mode). After isolation, write to the state file using the absolute path fixed during startup preparation (the auto-resolved path changes when cwd changes).
 
-**If launched with a cwd inside a worktree** (e.g., a parallel-cycle collision): EnterWorktree cannot create a nested worktree from inside one. Identify the main checkout and create your own worktree off main (or origin/main) with `git worktree add`, then move into it. Never touch files inside another agent's worktree.
+**If launched with a cwd inside a worktree** (e.g., a parallel-cycle collision): EnterWorktree cannot create a nested worktree from inside one. Identify the main checkout and create your own worktree off main (or origin/main) with `git worktree add`, then move into it. Never touch files inside another agent's worktree. If Edit/Write to the newly created worktree keeps being rejected (under subagent cwd pinning, `EnterWorktree(path)` may report success while the write boundary does not actually move — 2026-07-15 FB): clean up the new worktree with `git worktree remove`, then continue by swapping only the branch inside the pinned original worktree directory via `git checkout -b <branch> origin/<base-ref>` (the original branch's commits are preserved).
 
 Read the plan and determine the type of implementation:
 

--- a/claude/ja/agents/dev-cycle.md
+++ b/claude/ja/agents/dev-cycle.md
@@ -100,7 +100,7 @@ tools: Skill, Agent, Read, Write, Edit, Bash, Grep, Glob, TaskCreate, TaskUpdate
 
 **実装に入る前に `EnterWorktree` で分離する** (design doc §7 row4「git worktree で分離」に対応。loop-mode・対話mode共通)。分離後は state file への書き込みに Step起動時の準備で確定した絶対パスを使う (cwd変化で自動解決パスが変わるため)。
 
-**worktree 内の cwd で起動された場合** (並列 cycle の衝突等): EnterWorktree は worktree 内からのネスト作成ができない。main checkout を特定し、`git worktree add` で自前の worktree を main (or origin/main) から作成して移動する。他 agent の worktree 内のファイルには触れない。
+**worktree 内の cwd で起動された場合** (並列 cycle の衝突等): EnterWorktree は worktree 内からのネスト作成ができない。main checkout を特定し、`git worktree add` で自前の worktree を main (or origin/main) から作成して移動する。他 agent の worktree 内のファイルには触れない。作成した新規 worktree への Edit/Write が拒否され続ける場合 (subagent の cwd pin 下では `EnterWorktree(path)` が成功を報告しても書き込み境界が移らない — 2026-07-15 FB): 新規 worktree を `git worktree remove` で片付け、pin 済みの元 worktree ディレクトリ内で `git checkout -b <branch> origin/<base-ref>` によりブランチだけ差し替えて続行する (元ブランチの commit は保持される)。
 
 plan を読み、実装内容のタイプを判定:
 

--- a/claude/ja/skills/work-intake/references/notion-adapter.md
+++ b/claude/ja/skills/work-intake/references/notion-adapter.md
@@ -24,6 +24,8 @@ work-intake: spec contract 未充足のため skip
 参照: rules/spec-contract.md
 ```
 
+- **再コメント抑止 (idempotency)**: 投稿前に `notion-get-comments` で既存コメントを確認し、既に work-intake の skip コメントが付いていて spec 本文がその後未更新なら再コメントしない (skip 判定の報告のみ行う)。loop 化した際に poll のたびコメントが積もるのを防ぐ
+
 ## 注意
 
 - ticket 本文の編集 (`notion-update-page` での本文変更) はしない。触って良いのは status プロパティとコメントのみ

--- a/claude/skills/work-intake/references/notion-adapter.md
+++ b/claude/skills/work-intake/references/notion-adapter.md
@@ -26,6 +26,8 @@ work-intake: skipped due to unmet spec contract
 Reference: rules/spec-contract.md
 ```
 
+- **Re-comment suppression (idempotency)**: before posting, check existing comments with `notion-get-comments`; if a work-intake skip comment already exists and the spec body has not been updated since, do not comment again (only report the skip verdict). This prevents comments from piling up on every poll once this runs in a loop.
+
 ## Notes
 
 - Do not edit the ticket body (changing the body via `notion-update-page`). Only the status property and comments may be touched


### PR DESCRIPTION
## improve-harness 改善 PR (2026-07-16 run)

knowledge loop の apply 側。未処理 insight 15 件を集約・現状照合した結果、未適用だった 2 件を反映。

### insight ↔ 変更 対応表

| insight (file) | commit | 変更 |
|---|---|---|
| 20260714-work-intake-skip-idempotency.md | 06849dc | notion-adapter の skip コメント手順に再コメント抑止 (idempotency) を追加 (ja SoT + en mirror) |
| 20260715-enterworktree-path-ignored-when-cwd-pinned.md | 49c3ecd | dev-cycle の worktree 手順に cwd pin 時の branch 差し替え recovery を明文化 (ja SoT + en mirror) |

### 照合で適用済み・PR 対象外だった insight

- 適用済み確認 (7 件): ready-flag SoT / retrospect 記録先 / work-intake memory scope / 優先度 vs 明示指示 / worktree 自己回復 / cycle 直列前提 / 実装 opus routing
- memory 直接適用 (1 件): bg job outward action の per-action 再承認 (対象 project memory へ登録、PR 不要)
- deferred (5 件): 下記 decisions-needed 参照

### decisions-needed (人間の判断待ち)

- 20260714-work-intake-skip-idempotency.md の代替案: skip 時に status を専用値 (例: needs-spec) へ変えるか — status 体系への介入のため要判断
- 20260715-background-review-agents-unrecoverable-after-interruption.md: self-review fan-out を run_in_background: false 既定にする件 — hard rule か推奨記載かが insight 上未定
- 20260714-interrupted-cycle-leaves-no-trace.md: 中断耐性 (工程境界 WIP commit / 定期 WIP push の 2 案) — Slice 2d escalation 設計への入力
- 20260714-atlas-migrate-lint-pro-gated.md: 対象 repo 側の課題 (3 案、external account 判断含む) — 対象 repo 側での ticket 化を提案
- 20260715-git-reset-hard-denied-worktree-resync.md: deny 済み command の代替手順を対象 project の memory に登録するか — classifier が「deny 回避手順の永続化」として拒否したため user 判断
- 20260713-validation-happy-path-bias.md: 検証原則への追記 — 対象が design doc (plans/) のため out-of-scope。design doc 更新 or rules/ 昇格は user 判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)