### PR TITLE
:bulb: codify memory promotion path in improve-harness skill

### DIFF
--- a/claude/ja/skills/improve-harness/SKILL.md
+++ b/claude/ja/skills/improve-harness/SKILL.md
@@ -28,7 +28,7 @@ frontmatter の `target` で振り分ける:
 | target | 扱い |
 |---|---|
 | harness 内 (`claude/` 配下 / `CLAUDE.md` / `rules/`) | 改善対象 → Step 3 へ |
-| harness 外 (他 repo のファイル / Claude Code 本体の挙動 / design doc・plans) | PR に含めない。「対象外報告」に回し、対象 project 側での対応提案を 1 行付けて `status: deferred` (reason: out-of-scope) |
+| harness 外 (他 repo のファイル / Claude Code 本体の挙動 / design doc・plans) | PR に含めない。memory 化で足りるもの (事実 / 環境の癖 / 代替 recipe) は Step 4 の memory 反映へ回す。それ以外は「対象外報告」に回し、対象 project 側での対応提案を 1 行付けて `status: deferred` (reason: out-of-scope) |
 
 ### Step 3: 現状照合
 
@@ -41,7 +41,7 @@ frontmatter の `target` で振り分ける:
 - 関連する insight をまとめて 1 改善単位 (cluster) にする
 - 反映先は `references/promotion.md` の基準で判定する。**memory → rules → skill → agent の昇格順**で、変更コストの小さい側に倒す
 - `target` が明記された insight はそれに従う (昇格判定は target 不明・横断パターンの時のみ)
-- **memory 反映は PR 不要**: 対象 project の memory に直接 write し、報告のみ
+- **memory 反映は PR 不要**: 対象 project の memory に直接 write し、報告のみ。memory 反映で完結した insight は `status: applied` (反映先 memory を併記)
 
 ### Step 5: 改善実装
 
@@ -77,7 +77,7 @@ frontmatter の `target` で振り分ける:
 | status | 意味 |
 |---|---|
 | (なし) | 未処理 |
-| `applied` | 既反映を照合で確認 (PR 不要) |
+| `applied` | 既反映を照合で確認、または memory 反映で完結 (PR 不要。memory の場合は反映先を併記) |
 | `proposed` | 改善 draft PR に含めた (`pr:` 併記) |
 | `deferred` | 要判断・対象外・別 work 割当 (`reason:` 併記) |
 
@@ -89,6 +89,7 @@ session JSONL の集計 (観点 skip 傾向・token 消費等) は user が明�
 
 - dotfiles に無関係な未 commit 変更がある場合: 触らず、改善 commit に含めない (明示 add — commit-push-branch の規約)
 - push / draft PR 作成が deny された場合: local commit まで保全し、branch 名を報告して停止する
+- memory write が deny された場合: 当該 insight を `status: deferred` (reason: write 拒否) にして要判断一覧へ回す
 
 ## 鉄則
 

--- a/claude/skills/improve-harness/SKILL.md
+++ b/claude/skills/improve-harness/SKILL.md
@@ -30,7 +30,7 @@ Sort by the `target` in the frontmatter:
 | target | handling |
 |---|---|
 | inside the harness (`claude/` subtree / `CLAUDE.md` / `rules/`) | improvement target → proceed to Step 3 |
-| outside the harness (files in other repos / Claude Code's own behavior / design docs / plans) | not included in the PR. Route to the "out-of-scope report", attach a one-line proposal for handling it on the target project's side, and set `status: deferred` (reason: out-of-scope) |
+| outside the harness (files in other repos / Claude Code's own behavior / design docs / plans) | not included in the PR. Items sufficiently handled as memory (facts / environment quirks / alternative recipes) are routed to Step 4's memory application. Everything else is routed to the "out-of-scope report", with a one-line proposal for handling it on the target project's side attached, and set to `status: deferred` (reason: out-of-scope) |
 
 ### Step 3: Reconcile against current state
 
@@ -43,7 +43,7 @@ Sort by the `target` in the frontmatter:
 - Group related insights into a single improvement unit (cluster)
 - Decide where to apply using the criteria in `references/promotion.md`. Following the **promotion order memory → rules → skill → agent**, fall to the side with the smaller change cost
 - An insight with an explicit `target` follows it (promotion decision applies only when the target is unclear or the pattern is cross-cutting)
-- **Applying to memory needs no PR**: write directly to the target project's memory and just report it
+- **Applying to memory needs no PR**: write directly to the target project's memory and just report it. An insight fully resolved by memory application gets `status: applied` (note the target memory alongside)
 
 ### Step 5: Implement the improvement
 
@@ -79,7 +79,7 @@ Sort by the `target` in the frontmatter:
 | status | meaning |
 |---|---|
 | (none) | unprocessed |
-| `applied` | already-applied, confirmed by reconciliation (no PR) |
+| `applied` | confirmed already applied by reconciliation, or fully resolved by memory application (no PR; for memory, note the target memory alongside) |
 | `proposed` | included in an improvement draft PR (`pr:` alongside) |
 | `deferred` | decision-needed / out-of-scope / assigned to separate work (`reason:` alongside) |
 
@@ -91,6 +91,7 @@ Session JSONL aggregation (perspective-skip tendencies / token consumption, etc.
 
 - If dotfiles has unrelated uncommitted changes: leave them untouched and do not include them in the improvement commit (explicit add — commit-push-branch's convention)
 - If push / draft PR creation is denied: preserve up to the local commit, report the branch name, and stop
+- If a memory write is denied: set that insight to `status: deferred` (reason: write denied) and route it to the decisions-needed list
 
 ## Iron rules
 


### PR DESCRIPTION
## Summary

improve-harness SKILL.md (ja SoT + en mirror) に、SP3 T4 検証 (PR #16) で観測した memory 昇格経路の実挙動を規範化。

## insight ↔ 変更対応表

| insight | 変更 |
|---|---|
| 20260717-improve-harness-routing-blocks-memory-promotion.md | Step 2 routing: harness 外 target のうち memory 化で足りるもの (事実 / 環境の癖 / 代替 recipe) は Step 4 の memory 反映へ回す経路を追加 |
| 20260717-improve-harness-memory-status-unspecified.md | Step 4 + status lifecycle: memory 反映で完結した insight は `status: applied` (反映先 memory 併記) と明文化 |
| 20260717-classifier-blocks-deny-workaround-memory-write.md | 障害時: memory write が deny された場合は当該 insight を `status: deferred` (reason: write 拒否) にして要判断一覧へ回す規定を追加 |

## 要判断 (人間へ)

なし (3 件とも単一具体案・T4 実挙動の規範化のみ)

---
根拠: CLAUDE.md loop-mode 例外規定 (improve-harness の harness 改善 draft PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)