### PR TITLE
:bulb: codify escalation-resume rule in dev-cycle review loop

### DIFF
--- a/claude/agents/dev-cycle.md
+++ b/claude/agents/dev-cycle.md
@@ -152,6 +152,7 @@ During implementation, follow the steps written in the plan. Always run the chec
 2. verdict = `approve` → stack nits onto the draft PR notes list, record follow-up proposals in the state file, and move to security review
 3. verdict = `fix-required` → apply the fix instructions (trivial ones with your own Edit, substantive changes delegated to the implementation subagent = opus) → confirm build / test / lint green → go back to 1 and re-spawn (iteration +1)
 4. verdict = `escalation`, or **iteration exceeds the max of 3 without reaching approve** → escalation (in this Slice, up to stop-and-report to the user. Automated ticket comments and push notifications come in Slice 2d)
+5. **Resuming after escalation resolution**: if the change applied after resolution is exactly the reviewer-specified remediation, no re-review is needed (state this explicitly in the draft PR). If it involves additional changes beyond what the reviewer specified, reset the iteration cap and re-spawn from 1
 
 - **Detection of a new dependency escalates unconditionally regardless of the verdict** (an existing CLAUDE.md wall; not relaxed even in loop-mode)
 - Since the next round's reviewer sees the whole diff fresh, areas newly touched by a fix are structurally covered too, so incremental oversights don't slip through

--- a/claude/ja/agents/dev-cycle.md
+++ b/claude/ja/agents/dev-cycle.md
@@ -150,6 +150,7 @@ plan を読み、実装内容のタイプを判定:
 2. verdict = `approve` → nit を draft PR 注記リストに積み、follow-up 提案を state file に記録して security review へ
 3. verdict = `fix-required` → 修正指示を実施する (軽微は自前 Edit、実質的な変更は実装 subagent = opus へ委譲) → build / test / lint green を確認 → 1 へ戻り再 spawn (iteration +1)
 4. verdict = `escalation`、または **iteration が上限 3 を超えても approve に至らない** → escalation (このSliceではユーザーへの停止報告まで。ticketコメント自動投稿・push通知は Slice 2d)
+5. **escalation 解消後の再開**: 解消後に適用した変更が reviewer 指定の remediation そのものであれば再 review は不要 (その旨を draft PR に明記する)。reviewer の指定を超える追加変更を伴う場合は iteration cap をリセットして 1 から再 spawn する
 
 - **新規 dependency の検出は verdict に関わらず無条件で escalation** (CLAUDE.mdの既存の壁、loop-modeでも緩めない)
 - 修正で新たに触れた箇所も次周の reviewer が fresh で diff 全体を見るため、増分の見落としが構造的に出ない


### PR DESCRIPTION
## improve-harness 改善 PR (2026-07-19 run)

knowledge loop の apply 側。未処理 insight 1 件を集約・現状照合した結果を反映。

### insight ↔ 変更 対応表

| insight (file) | 変更 |
|---|---|
| 20260719-review-loop-escalation-resume-unspecified.md | dev-cycle の review 反復 loop に item 5「escalation 解消後の再開」を追加: reviewer 指定の remediation そのままなら再 review 不要 (PR に明記)、指定を超える追加変更は cap をリセットして再 spawn (ja SoT + en mirror) |

### decisions-needed (人間の判断待ち)

なし (単一具体案・実運用で観測済みの挙動の規範化のみ)。既存 deferred 群 (background-review-agents の bg 既定 / interrupted-cycle / atlas / validation-happy-path-bias) は変更なし — 2d ほかで消化予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)