### PR TITLE
:sparkles: add dev-loop driver skill for /loop-based autonomous operation (SP4)

### DIFF
--- a/claude/agents/dev-cycle.md
+++ b/claude/agents/dev-cycle.md
@@ -18,7 +18,7 @@ An **orchestrator subagent** that runs one development cycle (plan → implement
 | **interactive mode (option)** | the user directly passes a ticket URL / natural-language spec with an instruction like "push it through end-to-end" (the ready gate does not apply — see spec-contract "the meaning of ready") | Keeps the traditional 3 checkpoints (plan approval, self-review fix approval, pre-commit confirmation) |
 
 If the input is a work-intake-format work item, judge it as loop-mode; if the user directly passes a ticket URL/spec and instructs end-to-end progress, judge it as interactive mode.
-Invoking `work-intake` is the caller's responsibility (the user / main session for manual kicks, the loop driver in Phase 2). This agent is the receiver of a work item; it does not enumerate tickets itself.
+Invoking `work-intake` is the caller's responsibility (the user / main session for manual kicks, the `dev-loop` skill under /loop operation). This agent is the receiver of a work item; it does not enumerate tickets itself.
 
 ## Activation conditions
 

--- a/claude/ja/agents/dev-cycle.md
+++ b/claude/ja/agents/dev-cycle.md
@@ -16,7 +16,7 @@ tools: Skill, Agent, Read, Write, Edit, Bash, Grep, Glob, TaskCreate, TaskUpdate
 | **対話 mode (option)** | ticket URL / 自然言語 spec をユーザーが直接渡し「一気通貫で進めて」等と指示 (ready gate は適用外 — spec-contract「ready の意味」参照) | 従来の3箇所 (計画承認・self-review修正承認・commit直前確認) を維持 |
 
 入力が work-intake形式の work item ならloop-mode、ユーザーが直接ticket URL/specを渡して一気通貫進行を指示したら対話modeと判定する。
-`work-intake` の起動は呼び出し側の責務 (手動 kick では user / main session、Phase 2 では loop driver)。本 agent は work item を受け取る側で、自分では列挙しない。
+`work-intake` の起動は呼び出し側の責務 (手動 kick では user / main session、/loop 運転では `dev-loop` skill)。本 agent は work item を受け取る側で、自分では列挙しない。
 
 ## 起動条件
 

--- a/claude/ja/skills/dev-loop/SKILL.md
+++ b/claude/ja/skills/dev-loop/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dev-loop
+description: /loop で回す dev loop の driver skill。1 tick = work-intake poll → (work item があれば) dev-cycle を直列実行 → receipts 検証済みの完了 / escalation 通知 → ScheduleWakeup で次 tick の self-pacing。「dev-loop の tick を実行して」「dev loop 回して」等で使う (通常は /loop 経由)。cycle の中身は dev-cycle が SoT — 本 skill は駆動のみ。
+---
+
+# dev-loop
+
+Dev loop の driver。**loop の生死は user の /loop 操作が管理し、本 skill は 1 tick の中身を規定する**。1 tick = 1 poll + 最大 1 cycle。
+
+## 適用条件
+
+- /loop (dynamic pacing) からの起動が前提 (単発 tick の手動実行も可)
+- 対象 repo の cwd / Notion MCP が使える local session (interactive auth のため headless 不可)
+
+## 手順 (1 tick)
+
+### Step 1: 前提確認
+
+- git repo 内であること
+- **直列 guard**: per-project plans dir の state file 群を確認し、active な cycle (Current state が全工程完了 / escalation 停止を示していない state file) が存在しないこと。存在するなら本 tick は cycle を起動せず Step 5 へ (300s wakeup — 実行中 cycle の完了待ち)
+- Notion 到達性は work-intake に委ねる (不達なら Step 2 が異常終了 → 「Notion 不達」を通知して 1800s wakeup)
+
+### Step 2: poll (`work-intake`)
+
+- `work-intake` skill を起動する
+- 該当なし (work item 0 件) → Step 5 (idle 間隔)
+- work item が返ったら Step 3 へ
+
+### Step 3: cycle (`dev-cycle` 直列実行)
+
+- `dev-cycle` を**通常の Agent tool で spawn する — teams を使わない** (flat roster 下では nested spawn 不可で review fan-out が inline 縮退するため。通常 spawn の nested fan-out は実証済み)
+- **同期起動 (`run_in_background: false`)** — 完了まで待つ。1 tick 最大 1 cycle、並列起動しない
+- prompt には work item 全文を渡す (dev-cycle 側で loop-mode と判定される)
+
+### Step 4: 通知 (receipts の実在検証後)
+
+dev-cycle の報告から receipts を取り、**実在を機械確認してから** `PushNotification` で通知する:
+
+| 結果 | 検証 | 通知 |
+|---|---|---|
+| 完走 | PR URL を `gh pr view` で確認 | 「<ticket-id>: draft PR <URL>」 |
+| escalation | ticket コメント / WIP branch (`git ls-remote`) を確認 | 「<ticket-id>: escalation (<停止理由 1 行>)」 |
+| receipts が実在しない | — | 「<ticket-id>: 報告と実態の乖離を検出」+ escalation 扱いでカウント |
+
+- PushNotification が使えない場合は tick 報告に「通知未達」を明記する (沈黙しない)
+
+### Step 5: self-pacing (`ScheduleWakeup`)
+
+| 直前の結果 | 次 wakeup | 理由 |
+|---|---|---|
+| cycle 完走 | 60-120s | drain — 続きの ready をすぐ消化 |
+| 空 queue (該当なし) | 1200-1800s | idle (20-30 分) |
+| escalation | 1200-1800s | 通常継続 (対象 ticket は InProgress で再 pick されない) |
+| 直列 guard hit | 300s | 実行中 cycle の完了待ち |
+| Notion 不達 | 1800s | 復旧待ち |
+
+- **連続 escalation breaker**: escalation (乖離検出を含む) が **3 連続**したら wakeup を止め (`ScheduleWakeup` stop)、「loop 停止 (escalation 3 連続)」を通知して終了する。連続カウントは cycle 完走でリセット
+
+### Step 6: tick の報告 (強制出力)
+
+```
+## dev-loop tick 報告
+- poll: [該当なし / <ticket-id> を選択]
+- cycle: [未実行 / 完走 (PR <URL>) / escalation (<理由>)] — receipts: <検証済み一覧>
+- escalation 連続: <n>/3
+- 次 wakeup: <秒> (<理由>)
+```
+
+## 鉄則
+
+1. **並列 cycle を起動しない** — 直列 guard を skip しない
+2. **通知は receipts の実在検証後** — dev-cycle の自己申告をそのまま転送しない
+3. **escalation で loop を止めない** — 例外は 3 連続 breaker のみ
+4. **loop の恒久停止は user の /loop 操作** — breaker 発動時も「停止した」通知を必ず送る
+5. **tick 報告を省略しない** — 全項目を毎 tick 出力する

--- a/claude/skills/dev-loop/SKILL.md
+++ b/claude/skills/dev-loop/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: dev-loop
+description: Driver skill for the dev loop run via /loop. 1 tick = work-intake poll → (if there is a work item) run dev-cycle serially → completion with verified receipts / escalation notification → ScheduleWakeup to self-pace the next tick. Use for 「dev-loop の tick を実行して」("run the dev-loop tick"), 「dev loop 回して」("run the dev loop"), etc. (normally via /loop). The cycle's internals are the dev-cycle SoT — this skill only drives.
+---
+
+> **Source of truth:** `claude/ja/skills/dev-loop/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# dev-loop
+
+The dev loop's driver. **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most 1 cycle.
+
+## Applicability conditions
+
+- Startup from /loop (dynamic pacing) is assumed (a single manual tick is also fine)
+- A local session where the target repo's cwd / Notion MCP is available (headless is not possible due to interactive auth)
+
+## Procedure (1 tick)
+
+### Step 1: Precondition check
+
+- Must be inside a git repo
+- **Serial guard**: check the state files in the per-project plans dir, and ensure no active cycle exists (a state file whose Current state does not indicate all-stages-complete / escalation stop). If one exists, this tick does not start a cycle and goes to Step 5 (300s wakeup — waiting for the running cycle to finish)
+- Leave Notion reachability to work-intake (if unreachable, Step 2 terminates abnormally → notify "Notion unreachable" and 1800s wakeup)
+
+### Step 2: poll (`work-intake`)
+
+- Start the `work-intake` skill
+- None applicable (0 work items) → Step 5 (idle interval)
+- If a work item is returned, go to Step 3
+
+### Step 3: cycle (run `dev-cycle` serially)
+
+- **Spawn `dev-cycle` with the normal Agent tool — do not use teams** (under a flat roster, nested spawn is not possible and the review fan-out degrades to inline. Nested fan-out via normal spawn is proven)
+- **Synchronous startup (`run_in_background: false`)** — wait until completion. At most 1 cycle per tick; do not start in parallel
+- Pass the full work item text in the prompt (dev-cycle judges it as loop-mode)
+
+### Step 4: Notification (after verifying the receipts actually exist)
+
+Take the receipts from dev-cycle's report, and **notify via `PushNotification` only after mechanically confirming they actually exist**:
+
+| Result | Verification | Notification |
+|---|---|---|
+| Completed | Confirm the PR URL with `gh pr view` | 「<ticket-id>: draft PR <URL>」 |
+| escalation | Confirm the ticket comment / WIP branch (`git ls-remote`) | 「<ticket-id>: escalation (<one-line stop reason>)」 |
+| receipts do not actually exist | — | 「<ticket-id>: detected a divergence between report and reality」 + counted as escalation |
+
+- If PushNotification is unavailable, state "notification undelivered" explicitly in the tick report (do not go silent)
+
+### Step 5: self-pacing (`ScheduleWakeup`)
+
+| Immediately preceding result | Next wakeup | Reason |
+|---|---|---|
+| cycle completed | 60-120s | drain — consume the next ready right away |
+| empty queue (none applicable) | 1200-1800s | idle (20-30 min) |
+| escalation | 1200-1800s | normal continuation (the target ticket is InProgress and won't be re-picked) |
+| serial guard hit | 300s | waiting for the running cycle to finish |
+| Notion unreachable | 1800s | waiting for recovery |
+
+- **Consecutive escalation breaker**: if escalation (including divergence detection) occurs **3 consecutive** times, stop the wakeup (`ScheduleWakeup` stop), notify "loop stopped (3 consecutive escalations)", and terminate. The consecutive count resets on a cycle completion
+
+### Step 6: tick report (forced output)
+
+```
+## dev-loop tick report
+- poll: [none applicable / selected <ticket-id>]
+- cycle: [not run / completed (PR <URL>) / escalation (<reason>)] — receipts: <verified list>
+- escalation streak: <n>/3
+- next wakeup: <seconds> (<reason>)
+```
+
+## Iron rules
+
+1. **Do not start parallel cycles** — do not skip the serial guard
+2. **Notify only after verifying the receipts actually exist** — do not forward dev-cycle's self-report as-is
+3. **Do not stop the loop on escalation** — the only exception is the 3-consecutive breaker
+4. **Permanent loop stop is the user's /loop operation** — even when the breaker fires, always send the "stopped" notification
+5. **Do not omit the tick report** — output all items every tick


### PR DESCRIPTION
## Summary
- new `dev-loop` skill (ja SoT + en mirror) — the driver for unattended dev-loop operation via dynamic `/loop`. One tick = serial guard (state-file reverse lookup) → work-intake poll → synchronous dev-cycle spawn (**no teams** — avoids the flat-roster fan-out degradation) → **receipts-verified** PushNotification (completion / escalation / report-vs-reality mismatch detection) → ScheduleWakeup self-pacing (drain 60-120s / idle 20-30 min / guard 300s)
- consecutive-escalation breaker: 3 in a row stops the loop with a notification; single escalations keep the loop running (escalated tickets stay InProgress and are not re-picked)
- notifications are sent from the main session (resolves the "PushNotification in subagent" unknown) and only after machine-verifying the cycle's receipts — the driver never relays self-reported success
- dev-cycle caller reference updated to name `dev-loop`

## Validation (SP4 DoD, fresh session)
- place a tiny ticket in Backlog → start `/loop` with a dev-loop tick → observe empty-queue tick + idle wakeup → set the ticket Ready and touch nothing → next tick autonomously produces a draft PR + completion notification = **DoD: draft PR with no human kick**
- drain (second Ready consumed within 60-120s), escalation continuation + breaker (temporarily =1), and first live observation of PushNotification delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)