### PR TITLE
:bulb: record notification outcome tri-state in dev-loop tick report

### DIFF
--- a/claude/ja/skills/dev-loop/SKILL.md
+++ b/claude/ja/skills/dev-loop/SKILL.md
@@ -42,7 +42,7 @@ dev-cycle の報告から receipts を取り、**実在を機械確認してか�
 | escalation | ticket コメント / WIP branch (`git ls-remote`) を確認 | 「<ticket-id>: escalation (<停止理由 1 行>)」 |
 | receipts が実在しない | — | 「<ticket-id>: 報告と実態の乖離を検出」+ escalation 扱いでカウント |
 
-- PushNotification が使えない場合は tick 報告に「通知未達」を明記する (沈黙しない)
+- 通知結果は **3 区分**で扱い、tick 報告に必ず記す: **送信** (発行された) / **skip (terminal active)** = user が terminal で active なため tool が意図的に抑止 — **正常** (通知は無人時のみ配達される仕様) / **未達** (tool 不可・エラー — 異常。沈黙しない)
 
 ### Step 5: self-pacing (`ScheduleWakeup`)
 
@@ -63,6 +63,7 @@ dev-cycle の報告から receipts を取り、**実在を機械確認してか�
 - poll: [該当なし / <ticket-id> を選択]
 - cycle: [未実行 / 完走 (PR <URL>) / escalation (<理由>)] — receipts: <検証済み一覧>
 - escalation 連続: <n>/3
+- 通知: [送信 / skip (terminal active — 正常) / 未達 / 対象なし]
 - 次 wakeup: <秒> (<理由>)
 ```
 

--- a/claude/skills/dev-loop/SKILL.md
+++ b/claude/skills/dev-loop/SKILL.md
@@ -44,7 +44,7 @@ Take the receipts from dev-cycle's report, and **notify via `PushNotification` o
 | escalation | Confirm the ticket comment / WIP branch (`git ls-remote`) | 「<ticket-id>: escalation (<one-line stop reason>)」 |
 | receipts do not actually exist | — | 「<ticket-id>: detected a divergence between report and reality」 + counted as escalation |
 
-- If PushNotification is unavailable, state "notification undelivered" explicitly in the tick report (do not go silent)
+- Notification outcomes are handled in **3 categories** and always recorded in the tick report: **sent** (issued) / **skipped (terminal active)** = the tool deliberately suppressed it because the user is active at the terminal — **normal** (notifications are only delivered when unattended, by design) / **not delivered** (tool unavailable / error — abnormal; never stay silent)
 
 ### Step 5: self-pacing (`ScheduleWakeup`)
 
@@ -65,6 +65,7 @@ Take the receipts from dev-cycle's report, and **notify via `PushNotification` o
 - poll: [none applicable / selected <ticket-id>]
 - cycle: [not run / completed (PR <URL>) / escalation (<reason>)] — receipts: <verified list>
 - escalation streak: <n>/3
+- notification: [sent / skipped (terminal active — normal) / not delivered / n/a]
 - next wakeup: <seconds> (<reason>)
 ```
 


### PR DESCRIPTION
## improve-harness 改善 PR (2026-07-22 run)

未処理 insight 1 件を反映。

| insight (file) | 変更 |
|---|---|
| 20260722-pushnotification-suppressed-when-terminal-active.md | dev-loop Step 4 + tick 報告に通知結果の 3 区分を明記: 送信 / **skip (terminal active = 正常 — 通知は無人時のみ配達される仕様)** / 未達 (異常)。SP4 T4 で判明した PushNotification の抑止仕様 (terminal active 中は意図的 skip) の規範化 (ja SoT + en mirror) |

decisions-needed: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)