### PR TITLE
:sparkles: dev-loop local-time tick clock + principal-engineer standpoint for judgment reviewers

### DIFF
--- a/claude/agents/independent-reviewer.md
+++ b/claude/agents/independent-reviewer.md
@@ -11,6 +11,8 @@ model: opus
 
 A second reviewer whose purpose is the **structural elimination of implementer bias**. Not bound by a perspective checklist (that's review-lens's job), it looks cross-cuttingly, with an external reviewer's eye, at "does this diff keep the spec's promises / is it breaking anything?"
 
+**Review from a principal engineer's standpoint**: beyond "does it match the spec", hold your own questions — "is this change right for the maintainer six months from now" and "is the spec itself defective — is the implementation papering over that". Pointing out spec defects is not out of scope; it is this agent's core job.
+
 ## Input (received via the prompt)
 
 - The diff range to review (branch / commit range)

--- a/claude/agents/review-orchestrator.md
+++ b/claude/agents/review-orchestrator.md
@@ -11,6 +11,8 @@ model: opus
 
 The review-side principal of dev-cycle's review iteration loop. A **fresh spawn with no implementation context**, it judges from the conventions, the spec, and the diff alone — extending independent-reviewer's independence principle across the whole review stage. It does not fix; it returns a verdict and fix instructions.
 
+**Integrate and judge from a principal engineer's standpoint**: you are not a tallier of findings — before issuing the verdict, ask yourself "is this the right change" and "am I missing a defect in the spec itself or a crack in the design".
+
 ## Input (received via the prompt)
 
 - The diff range to review (branch / commit range)

--- a/claude/ja/agents/independent-reviewer.md
+++ b/claude/ja/agents/independent-reviewer.md
@@ -9,6 +9,8 @@ model: opus
 
 **実装者バイアスの構造的排除**が目的の second reviewer。観点 checklist (review-lens の担当) には縛られず、「この diff は spec の約束を守れているか / 壊しているものはないか」を外部 reviewer の目で横断的に見る。
 
+**principal engineer の視座で見る**: 「spec 通りか」に加えて「この変更は 6 ヶ月後の保守者にとって正しいか」「spec 自体に欠陥はないか — 実装がそれを糊塗していないか」を自分の問いとして持つ。spec の欠陥の指摘は scope 外ではなく本 agent の中心業務。
+
 ## 入力 (prompt で受け取る)
 
 - review 対象の diff 範囲 (branch / commit range)

--- a/claude/ja/agents/review-orchestrator.md
+++ b/claude/ja/agents/review-orchestrator.md
@@ -9,6 +9,8 @@ model: opus
 
 dev-cycle の review 反復 loop の review 側主体。**実装 context を持たない fresh spawn** で、規約と spec と diff だけから判断する — independent-reviewer の独立性原理を review 工程全体に拡張したもの。修正は行わず、verdict と修正指示を返す。
 
+**principal engineer の視座で統合判断する**: findings の集計者ではなく、「これは正しい変更か」「spec 自体の欠陥・設計の綻びを見逃していないか」を最後に自分へ問うてから verdict を出す。
+
 ## 入力 (prompt で受け取る)
 
 - review 対象の diff 範囲 (branch / commit range)

--- a/claude/ja/skills/api-design-review/SKILL.md
+++ b/claude/ja/skills/api-design-review/SKILL.md
@@ -6,7 +6,7 @@ model: claude-fable-5
 
 # api-design-review
 
-API / システム上流設計の **turn を跨いだ段階的発覚を防ぐ** ための系統的レビュー skill。read-only (Edit / Write しない、Bash で grep のみ可)。
+API / システム上流設計の **turn を跨いだ段階的発覚を防ぐ** ための系統的レビュー skill。read-only (Edit / Write しない、Bash で grep のみ可)。**principal engineer の視座で行う**: 表現の妥当性ではなく設計判断そのものの正しさ — 将来の拡張・運用・保守者にとって正しいか — を問う。
 
 考慮漏れの源泉は wire 表現 (proto / OpenAPI) ではなく、その **前段のドメイン設計 / use case 分析 / ACL モデル / API 体験設計** にあるため、proto を書き始める **前** に通すのが最も効果的。proto を触り始めてからの review は補完用。
 

--- a/claude/ja/skills/dev-loop/SKILL.md
+++ b/claude/ja/skills/dev-loop/SKILL.md
@@ -16,6 +16,7 @@ Dev loop の driver。**loop の生死は user の /loop 操作が管理し、�
 
 ### Step 1: 前提確認
 
+- `date '+%Y-%m-%d %H:%M %Z'` を実行して現在時刻 (現地) を取得する — tick 報告の時刻欄用。時刻を推測で書かない
 - git repo 内であること
 - **直列 guard**: per-project plans dir の state file 群を確認し、active な cycle (Current state が全工程完了 / escalation 停止を示していない state file) が存在しないこと。存在するなら本 tick は cycle を起動せず Step 5 へ (300s wakeup — 実行中 cycle の完了待ち)
 - Notion 到達性は work-intake に委ねる (不達なら Step 2 が異常終了 → 「Notion 不達」を通知して 1800s wakeup)
@@ -60,11 +61,12 @@ dev-cycle の報告から receipts を取り、**実在を機械確認してか�
 
 ```
 ## dev-loop tick 報告
+- 時刻: <現在時刻 (現地)> — 前回 tick: <前回報告の時刻 / 不明>
 - poll: [該当なし / <ticket-id> を選択]
 - cycle: [未実行 / 完走 (PR <URL>) / escalation (<理由>)] — receipts: <検証済み一覧>
 - escalation 連続: <n>/3
 - 通知: [送信 / skip (terminal active — 正常) / 未達 / 対象なし]
-- 次 wakeup: <秒> (<理由>)
+- 次 wakeup: <秒> (~<HH:MM> 頃 / <理由>)
 ```
 
 ## 鉄則

--- a/claude/skills/api-design-review/SKILL.md
+++ b/claude/skills/api-design-review/SKILL.md
@@ -8,7 +8,7 @@ model: claude-fable-5
 
 # api-design-review
 
-A systematic review skill for API / upstream system design that **prevents issues from surfacing piecemeal across turns**. Read-only (no Edit / Write; only grep via Bash is allowed).
+A systematic review skill for API / upstream system design that **prevents issues from surfacing piecemeal across turns**. Read-only (no Edit / Write; only grep via Bash is allowed). **Performed from a principal engineer's standpoint**: question not the adequacy of the expression but the rightness of the design decision itself — right for future extension, operations, and maintainers.
 
 The source of overlooked considerations isn't the wire representation (proto / OpenAPI) but the **domain design / use-case analysis / ACL model / API experience design that precedes it** — so running this **before** starting to write proto is most effective. Reviewing after proto work has already begun is only supplementary.
 

--- a/claude/skills/dev-loop/SKILL.md
+++ b/claude/skills/dev-loop/SKILL.md
@@ -18,6 +18,7 @@ The dev loop's driver. **The loop's lifecycle is managed by the user's /loop ope
 
 ### Step 1: Precondition check
 
+- Run `date '+%Y-%m-%d %H:%M %Z'` to get the current local time — for the tick report's time line; never guess the time
 - Must be inside a git repo
 - **Serial guard**: check the state files in the per-project plans dir, and ensure no active cycle exists (a state file whose Current state does not indicate all-stages-complete / escalation stop). If one exists, this tick does not start a cycle and goes to Step 5 (300s wakeup — waiting for the running cycle to finish)
 - Leave Notion reachability to work-intake (if unreachable, Step 2 terminates abnormally → notify "Notion unreachable" and 1800s wakeup)
@@ -62,11 +63,12 @@ Take the receipts from dev-cycle's report, and **notify via `PushNotification` o
 
 ```
 ## dev-loop tick report
+- time: <current local time> — previous tick: <time from previous report / unknown>
 - poll: [none applicable / selected <ticket-id>]
 - cycle: [not run / completed (PR <URL>) / escalation (<reason>)] — receipts: <verified list>
 - escalation streak: <n>/3
 - notification: [sent / skipped (terminal active — normal) / not delivered / n/a]
-- next wakeup: <seconds> (<reason>)
+- next wakeup: <seconds> (~<HH:MM> / <reason>)
 ```
 
 ## Iron rules


### PR DESCRIPTION
## Summary
- **dev-loop tick clock**: Step 1 now fetches local time via `date` (never guessed); the tick report leads with `time: <now> — previous tick: <prev>`, and next-wakeup shows an absolute `~HH:MM` alongside seconds — a glance at a long-running loop session tells you when it last fired and when it fires next
- **principal-engineer standpoint** added to the three judgment reviewers (ja SoT + en mirror):
  - independent-reviewer: "is this right for the maintainer six months out / is the spec itself defective — is the implementation papering over it"; spec-defect findings codified as core duty
  - review-orchestrator: not a tallier of findings — self-check "is this the right change / am I missing a spec defect or design crack" before issuing a verdict
  - api-design-review: question the rightness of the design decision itself, not the adequacy of its expression
- deliberately NOT applied to review-lens (scope discipline is its virtue) and implementation subagents (raising the implementer's altitude increases scope-creep risk; quality floor is owned by tests + the review loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)