### PR TITLE
:sparkles: add review-loop driver skill for /loop-based autonomous PR review

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -48,6 +48,7 @@
 - loop-mode = dev-cycle agent が spec (`rules/spec-contract.md` を満たす work item) を起点に自律実行する mode。人間の承認手続きを各工程の機械的 policy に置換する
 - 例外として許可: `commit-push-branch` (loop-mode 拡張) 経由の feature branch push + **draft PR 作成**
 - improve-harness (knowledge loop) も同例外を使える: harness 改善の draft PR 作成まで (対象 repo は dotfiles のみ)
+- review-loop も同例外を使える: watch 対象 PR への **review comment 投稿**まで (approve / request-changes / merge は引き続き人間のみ)
 - 引き続き禁止: merge / draft の本 PR 化 / main への直 push / 新規 dependency 追加 / 破壊的操作 / 外部送信の有効化 — 検出したら escalation (ticket コメント + 通知 + WIP branch push) して停止
 - 安全装置 (hooks / permission deny / least privilege) は loop-mode でも一切緩めない
 - superpowers 棲み分け: 自律 pipeline (dev loop) では superpowers の process skill を使わない (背骨は自前 skill)。対話 session での brainstorming / TDD 参照は可

--- a/claude/agents/review-orchestrator.md
+++ b/claude/agents/review-orchestrator.md
@@ -17,7 +17,7 @@ The review-side principal of dev-cycle's review iteration loop. A **fresh spawn 
 
 - The diff range to review (branch / commit range)
 - The full spec / work item (DoD / non-goals / constraints)
-- The impact-scope classification (impact-A/B/C and the "target symbol → referencing sites" mapping)
+- The impact-scope classification (impact-A/B/C and the "target symbol → referencing sites" mapping). **If omitted (e.g., standalone invocation), judge it from the diff yourself**
 - The **path list** of repo conventions / design docs (the original paths, not a digest — it reads them itself)
 - The iteration number + the previous round's fix instructions (from the 2nd round on)
 

--- a/claude/ja/agents/review-orchestrator.md
+++ b/claude/ja/agents/review-orchestrator.md
@@ -15,7 +15,7 @@ dev-cycle の review 反復 loop の review 側主体。**実装 context を持�
 
 - review 対象の diff 範囲 (branch / commit range)
 - spec / work item 全文 (DoD / non-goals / 制約)
-- 影響範囲分類 (impact-A/B/C と「対象 symbol → 参照元」の対応)
+- 影響範囲分類 (impact-A/B/C と「対象 symbol → 参照元」の対応)。**省略された場合 (standalone 起動等) は diff から自分で判定する**
 - repo 規約・設計 docs の **path 一覧** (digest ではなく原本 path — 自分で読む)
 - iteration 番号 + 前周の修正指示 (2 周目以降)
 

--- a/claude/ja/skills/review-loop/SKILL.md
+++ b/claude/ja/skills/review-loop/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: review-loop
+description: /loop で回す PR review の driver skill。1 tick = reviewer assign された open PR を poll → 未 review の head sha を 1 件選択 → review-orchestrator の統合 review → findings を中立 comment として投稿 (approve / merge はしない) → 通知 → ScheduleWakeup で self-pacing。「review-loop の tick を実行して」「review loop 回して」等で使う (通常は /loop 経由)。review の中身は review-orchestrator が SoT — 本 skill は駆動のみ。
+---
+
+# review-loop
+
+PR review の driver (dev-loop の兄弟)。**loop の生死は user の /loop 操作が管理し、本 skill は 1 tick の中身を規定する**。1 tick = 1 poll + 最大 1 review。
+
+## 適用条件
+
+- /loop (dynamic pacing) からの起動が前提 (単発 tick の手動実行も可)
+- 対象 repo の cwd / `gh` 認証済みの local session
+
+## 手順 (1 tick)
+
+### Step 1: 前提確認
+
+- `date '+%Y-%m-%d %H:%M %Z'` を実行して現在時刻 (現地) を取得する — tick 報告用。時刻を推測で書かない
+- git repo 内であること / `gh auth status` が通ること
+
+### Step 2: poll (機械実行)
+
+```bash
+gh pr list --state open --search "review-requested:@me" \
+  --json number,headRefOid,title,isDraft,url,createdAt
+```
+
+- **自分に review request が来ている open PR** が対象 (draft 含む)。0 件なら Step 6 (idle) へ
+
+### Step 3: idempotency filter (機械実行)
+
+- 各 PR の comment を確認し、本 skill の marker **`<!-- review-loop: <head-sha> -->`** を探す
+- **現 head sha (`headRefOid`) が marker に一致する PR は skip** — 新 push で sha が変わった時だけ再 review する
+- 未 review の PR から **1 件**選択する (作成が古い順)。全件 skip なら Step 6 (idle) へ
+
+### Step 4: 統合 review (`review-orchestrator`)
+
+- `review-orchestrator` を**通常の Agent tool で同期 spawn する** (teams 不使用 — flat roster 下では fan-out が縮退するため)
+- 渡すもの: PR の diff 範囲 (base..head) / spec = **PR body + 本文が参照する ticket (あれば)** / repo 規約・設計 docs の path 一覧 (CLAUDE.md / rules / lint 設定 / docs 内設計文書を glob) / 簡易影響分類 (`gh pr diff <n> --stat` から: 新規 file のみ = impact-A、既存 file の変更あり = impact-C 相当として correctness / test-adversarial を重点指定)
+- state file 相当は渡さない (standalone review — 実装 context を持たせない)
+
+### Step 5: comment 投稿 (receipts 検証まで)
+
+- verdict + findings 表 + 観点実施状況を 1 本の comment に整形し、**冒頭に marker** を付けて投稿する:
+
+```bash
+gh pr comment <number> --body '<!-- review-loop: <head-sha> -->
+## 統合 review (review-loop)
+verdict: <approve / fix-required / escalation>
+<findings 表 / 観点実施状況 / 総評>'
+```
+
+- 投稿後に comment URL を取得して **receipt として実在確認**する
+- **approve / request-changes / merge / GitHub の review state は使わない** — 中立 comment のみ (merge 判断は人間)
+- secret / 内部 URL / code の丸ごと転記を comment に含めない (findings は file:line 参照)
+
+### Step 6: 通知 + self-pacing
+
+- **全 review 完了ごとに通知**: `PushNotification`「PR #<n> review 完了: <verdict>」。結果は 3 区分で tick 報告に記す — 送信 / **skip (terminal active — 正常、無人時のみ配達)** / 未達 (異常)
+
+| 直前の結果 | 次 wakeup (`ScheduleWakeup`) | 理由 |
+|---|---|---|
+| review 完了 | 60-120s | drain — 次の未 review PR をすぐ消化 |
+| 対象なし (0 件 or 全件 skip) | 1200-1800s | idle (20-30 分) |
+| review エラー | 900s | 再試行間隔 |
+
+- **連続エラー breaker**: review が **3 連続**で失敗したら wakeup を止め、「loop 停止 (review 3 連続失敗)」を通知して終了する。成功でリセット
+
+### Step 7: tick の報告 (強制出力)
+
+```
+## review-loop tick 報告
+- 時刻: <現在時刻 (現地)> — 前回 tick: <前回報告の時刻 / 不明>
+- poll: 対象 <N> 件 (うち review 済み skip <M> 件)
+- review: [なし / PR #<n> <verdict>] — receipts: <comment URL>
+- 通知: [送信 / skip (terminal active — 正常) / 未達 / 対象なし]
+- エラー連続: <n>/3
+- 次 wakeup: <秒> (~<HH:MM> 頃 / <理由>)
+```
+
+## 鉄則
+
+1. **approve / request-changes / merge をしない** — 中立 comment のみ
+2. **同一 head sha に再 comment しない** — marker 照合 (Step 3) を skip しない
+3. **通知・報告は receipts (comment URL) の実在検証後** — 自己申告で「投稿済み」と言わない
+4. **PR 本文・code を comment に丸ごと転記しない**
+5. **tick 報告を省略しない** — 全項目を毎 tick 出力する

--- a/claude/skills/review-loop/SKILL.md
+++ b/claude/skills/review-loop/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: review-loop
+description: Driver skill for PR review run via /loop. 1 tick = poll open PRs where I'm assigned as reviewer → select one un-reviewed head sha → integrating review via review-orchestrator → post findings as a neutral comment (does not approve / merge) → notify → ScheduleWakeup to self-pace. Use for 「review-loop の tick を実行して」("run the review-loop tick"), 「review loop 回して」("run the review loop"), etc. (normally via /loop). The review's substance is the review-orchestrator's SoT — this skill only drives.
+---
+
+> **Source of truth:** `claude/ja/skills/review-loop/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# review-loop
+
+The driver for PR review (dev-loop's sibling). **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most 1 review.
+
+## Applicability conditions
+
+- Startup from /loop (dynamic pacing) is assumed (a single manual tick is also fine)
+- A local session with the target repo's cwd / `gh` authenticated
+
+## Procedure (1 tick)
+
+### Step 1: Precondition check
+
+- Run `date '+%Y-%m-%d %H:%M %Z'` to get the current local time — for the tick report; never guess the time
+- Must be inside a git repo / `gh auth status` must pass
+
+### Step 2: poll (mechanical)
+
+```bash
+gh pr list --state open --search "review-requested:@me" \
+  --json number,headRefOid,title,isDraft,url,createdAt
+```
+
+- The target is **open PRs where a review request has come to me** (drafts included). If 0, go to Step 6 (idle)
+
+### Step 3: idempotency filter (mechanical)
+
+- Check each PR's comments and look for this skill's marker **`<!-- review-loop: <head-sha> -->`**
+- **Skip any PR whose current head sha (`headRefOid`) matches the marker** — re-review only when a new push changes the sha
+- Select **one** PR from the un-reviewed ones (oldest created first). If all are skipped, go to Step 6 (idle)
+
+### Step 4: integrating review (`review-orchestrator`)
+
+- **Spawn `review-orchestrator` synchronously with the normal Agent tool** (do not use teams — under a flat roster the fan-out degrades)
+- What to pass: the PR's diff range (base..head) / spec = **PR body + the ticket it references in the body (if any)** / the path list of repo conventions / design docs (glob CLAUDE.md / rules / lint configs / design documents under docs) / a simple impact classification (from `gh pr diff <n> --stat`: new files only = impact-A, changes to existing files = treated as impact-C, so mark correctness / test-adversarial as priorities)
+- Do not pass anything equivalent to a state file (standalone review — do not give it implementation context)
+
+### Step 5: comment posting (through receipts verification)
+
+- Format the verdict + findings table + perspective completion status into a single comment, and post it with the **marker at the top**:
+
+```bash
+gh pr comment <number> --body '<!-- review-loop: <head-sha> -->
+## Integrating review (review-loop)
+verdict: <approve / fix-required / escalation>
+<findings table / perspective completion status / overall assessment>'
+```
+
+- After posting, fetch the comment URL and **confirm it actually exists as a receipt**
+- **Do not use approve / request-changes / merge / GitHub's review state** — neutral comment only (the merge decision is the human's)
+- Do not include secrets / internal URLs / verbatim transcription of code in the comment (findings are file:line references)
+
+### Step 6: notification + self-pacing
+
+- **Notify on every review completion**: `PushNotification` "PR #<n> review complete: <verdict>". The outcome is recorded in the tick report in 3 categories — sent / **skipped (terminal active — normal, delivered only when unattended)** / not delivered (abnormal)
+
+| Immediately preceding result | Next wakeup (`ScheduleWakeup`) | Reason |
+|---|---|---|
+| review completed | 60-120s | drain — consume the next un-reviewed PR right away |
+| none applicable (0 or all skipped) | 1200-1800s | idle (20-30 min) |
+| review error | 900s | retry interval |
+
+- **Consecutive error breaker**: if a review fails **3 consecutive** times, stop the wakeup, notify "loop stopped (3 consecutive review failures)", and terminate. Resets on a success
+
+### Step 7: tick report (forced output)
+
+```
+## review-loop tick report
+- time: <current local time> — previous tick: <time from previous report / unknown>
+- poll: <N> targets (of which <M> skipped as already reviewed)
+- review: [none / PR #<n> <verdict>] — receipts: <comment URL>
+- notification: [sent / skipped (terminal active — normal) / not delivered / n/a]
+- error streak: <n>/3
+- next wakeup: <seconds> (~<HH:MM> / <reason>)
+```
+
+## Iron rules
+
+1. **Do not approve / request-changes / merge** — neutral comment only
+2. **Do not re-comment on the same head sha** — do not skip the marker check (Step 3)
+3. **Notify / report only after verifying the receipts (comment URL) actually exist** — do not claim "posted" on self-report
+4. **Do not transcribe the PR body / code verbatim into the comment**
+5. **Do not omit the tick report** — output all items every tick


### PR DESCRIPTION
## Summary
- new `review-loop` skill (ja SoT + en mirror) — the sibling of dev-loop: one tick = poll open PRs with `review-requested:@me` → pick one un-reviewed head sha (idempotency via a `<!-- review-loop: <head-sha> -->` marker embedded in the comment itself — no external state, re-reviews only on new pushes) → synchronous review-orchestrator run (repo conventions + PR body as spec, impact hint from `gh pr diff --stat`) → post findings as a **neutral comment only** (never approve / request-changes / merge) → receipts-verified notification on every review → ScheduleWakeup self-pacing (drain 60-120s / idle 20-30 min / 3-consecutive-error breaker)
- CLAUDE.md loop-mode exception extended by one line: review-loop may post review comments; approve / merge stay human-only (separate commit, as a rule change)
- review-orchestrator input relaxed: impact classification, if omitted (standalone invocation), is judged from the diff itself

## Validation (fresh session)
- create a small PR, assign yourself as reviewer → `/loop` with a review-loop tick → an unattended review comment + notification arrive = DoD
- same-sha skip → re-review only after a new push; confirm no GitHub review state (comment only); idle wakeup pacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)