### PR TITLE
:sparkles: define loop-mode PR body construction rules in commit-push-branch

### DIFF
--- a/claude/ja/skills/commit-push-branch/SKILL.md
+++ b/claude/ja/skills/commit-push-branch/SKILL.md
@@ -186,6 +186,7 @@ PR 作成は別タスク。ユーザーが指示したら `gh pr create` で続�
 | Spec compliance | DoD 各項目 ↔ 実装・テストの対応 (チェック結果) |
 | Spec deviations | SD# (無ければ "none") |
 | Impact scope | 変更 symbol → 参照元の mapping と impact 分類 |
+| Review guide | diff の読み順 (entry point → 本体 → test。impact scope の mapping から導出) / 重点確認箇所 (review 指摘を受けて修正した箇所・自信の低い箇所) / reviewer が手元で DoD を確認する手順 (DoD 検証手順から転記) |
 | Verification | test / lint 実行結果 + self-review・security review の結果 (観点実施状況を含む) |
 | References | ticket URL / 関連 doc |
 | Checklist | 機械的に判定できる項目のみ check (reviewer assign 等の人間項目は空欄のまま) |

--- a/claude/ja/skills/commit-push-branch/SKILL.md
+++ b/claude/ja/skills/commit-push-branch/SKILL.md
@@ -169,9 +169,30 @@ PR 作成は別タスク。ユーザーが指示したら `gh pr create` で続�
 - Step 3-6 の branch 名 / commit message は規約と過去スタイルで自動決定し、user 確認を挟まない
 - **WIP squash の適用判定 (機械実行)**: 作業 branch に `wip(<工程>):` commit が積まれている場合 (dev-cycle の工程境界 WIP commit)、squash の前に必ず `git ls-remote --heads origin <branch>` を実行する。**出力が空 (= 未 push) の場合のみ**、`git reset --soft $(git merge-base HEAD origin/<default-branch>)` で全変更を staged に戻してから規約通りの 1 commit を作る (`--hard` は使わない)。この場合 Step 5 の明示 add は「`git status` で staged 内容に secret / 対象外ファイルが混ざっていないことを確認する」に読み替える
 - **escalation で push 済みの branch では squash しない**: push 済み履歴の書き換えは force push が必要になり禁止と衝突する。wip の上に最終 commit を積み増してそのまま push する (fast-forward)。PR の commit 欄に wip が残るが、merge は squash merge 慣例のため default branch は汚れない
-- Step 7 の push 後に **draft PR を作成する**: `gh pr create --draft` (title = commit title、body = 呼び出し元から渡された実装計画 / DoD チェック結果 / review 結果)
+- Step 7 の push 後に **draft PR を作成する**: `gh pr create --draft` (title = commit title、body = 下記「PR body 構築規則」で組み立てる)
 - 本 PR 化 (draft 解除) と merge はしない
 - loop-mode 指定がない対話時の挙動は従来通り不変 (PR 作成は user 指示後)
+
+### PR body 構築規則 (loop-mode)
+
+呼び出し元 (dev-cycle) から渡される材料 = 実装計画 / DoD チェック結果 / spec deviation (SD#) / impact scope / self-review・security review 結果 (観点実施状況を含む) / ticket URL。これを次の規則で body に落とす:
+
+1. **対象 repo の PR template を探索**: `.github/pull_request_template.md` → `.github/PULL_REQUEST_TEMPLATE.md` → `PULL_REQUEST_TEMPLATE.md` → `docs/pull_request_template.md` の順で最初に見つかったもの
+2. **template があればその section 構成に従う**: HTML comment の記入 hint (`<!-- ... -->`) は削除し、各 section へ材料を対応付けて記入する。section 名は repo により異なるため意味で対応させる (目安):
+
+| template section (例) | 記入する材料 |
+|---|---|
+| Summary / Changes | 実装計画の要約 / 変更内容 |
+| Spec compliance | DoD 各項目 ↔ 実装・テストの対応 (チェック結果) |
+| Spec deviations | SD# (無ければ "none") |
+| Impact scope | 変更 symbol → 参照元の mapping と impact 分類 |
+| Verification | test / lint 実行結果 + self-review・security review の結果 (観点実施状況を含む) |
+| References | ticket URL / 関連 doc |
+| Checklist | 機械的に判定できる項目のみ check (reviewer assign 等の人間項目は空欄のまま) |
+
+   材料に対応する section が template に無い場合は body 末尾に section を追加して漏らさず記載する (黙って捨てない)
+3. **template が無ければ default skeleton で生成**: `## Summary` / `## Spec compliance` / `## Spec deviations` / `## Impact scope` / `## Verification` / `## References` の 6 section
+4. **repo の可視性で ticket 記載を分岐** (`gh repo view --json visibility` で機械判定): private repo は References に ticket URL を記載する (review-loop が「PR body + 参照 ticket」を spec として辿る前提)。**public repo では内部 URL / ticket 本文を書かない** (improve-harness 鉄則と同精神 — insights / ticket は名前・ID のみで参照)
 
 ## 鉄則
 

--- a/claude/ja/skills/commit-push-branch/SKILL.md
+++ b/claude/ja/skills/commit-push-branch/SKILL.md
@@ -182,11 +182,12 @@ PR 作成は別タスク。ユーザーが指示したら `gh pr create` で続�
 
 | template section (例) | 記入する材料 |
 |---|---|
-| Summary / Changes | 実装計画の要約 / 変更内容 |
-| Spec compliance | DoD 各項目 ↔ 実装・テストの対応 (チェック結果) |
+| Summary | 実装計画の要約 / 変更内容 (what & why) |
+| Spec compliance | DoD 各項目 ↔ 実装・テストの対応 (チェック結果)。表 skeleton があれば列構成に従う |
 | Spec deviations | SD# (無ければ "none") |
 | Impact scope | 変更 symbol → 参照元の mapping と impact 分類 |
-| Review guide | diff の読み順 (entry point → 本体 → test。impact scope の mapping から導出) / 重点確認箇所 (review 指摘を受けて修正した箇所・自信の低い箇所) / reviewer が手元で DoD を確認する手順 (DoD 検証手順から転記) |
+| Review guide | diff の読み順 (entry point → 本体 → test。file → symbol で指定し行番号を使わない — push で rot する) / 重点確認箇所 (review 指摘を受けて修正した箇所・自信の低い箇所) |
+| Compat & rollback | breaking の有無 / migration・env・config 変更と適用順 / rollback 手順 (該当なしなら "none / clean revert") |
 | Verification | test / lint 実行結果 + self-review・security review の結果 (観点実施状況を含む) |
 | References | ticket URL / 関連 doc |
 | Checklist | 機械的に判定できる項目のみ check (reviewer assign 等の人間項目は空欄のまま) |

--- a/claude/skills/commit-push-branch/SKILL.md
+++ b/claude/skills/commit-push-branch/SKILL.md
@@ -184,11 +184,12 @@ Materials passed from the caller (dev-cycle) = implementation plan / DoD check r
 
 | template section (example) | material to fill in |
 |---|---|
-| Summary / Changes | summary of the implementation plan / what changed |
-| Spec compliance | each DoD item ↔ its implementation & tests (check results) |
+| Summary | summary of the implementation plan / what changed (what & why) |
+| Spec compliance | each DoD item ↔ its implementation & tests (check results); follow the column layout if the template has a table skeleton |
 | Spec deviations | SD# ("none" if there are none) |
 | Impact scope | changed symbol → referencing-site mapping and impact classification |
-| Review guide | suggested diff reading order (entry point → core → tests, derived from the impact-scope mapping) / focus areas (spots reworked after review findings or with low confidence) / steps for a reviewer to verify the DoD locally (copied from the DoD verification procedures) |
+| Review guide | suggested diff reading order (entry point → core → tests; reference file → symbol, never line numbers — they rot across pushes) / focus areas (spots reworked after review findings or with low confidence) |
+| Compat & rollback | breaking changes / migration・env・config changes & ordering / rollback procedure ("none / clean revert" when not applicable) |
 | Verification | test / lint run results + self-review & security-review results (including perspective completion status) |
 | References | ticket URL / related docs |
 | Checklist | check only mechanically verifiable items (leave human items like reviewer assignment unchecked) |

--- a/claude/skills/commit-push-branch/SKILL.md
+++ b/claude/skills/commit-push-branch/SKILL.md
@@ -188,6 +188,7 @@ Materials passed from the caller (dev-cycle) = implementation plan / DoD check r
 | Spec compliance | each DoD item ↔ its implementation & tests (check results) |
 | Spec deviations | SD# ("none" if there are none) |
 | Impact scope | changed symbol → referencing-site mapping and impact classification |
+| Review guide | suggested diff reading order (entry point → core → tests, derived from the impact-scope mapping) / focus areas (spots reworked after review findings or with low confidence) / steps for a reviewer to verify the DoD locally (copied from the DoD verification procedures) |
 | Verification | test / lint run results + self-review & security-review results (including perspective completion status) |
 | References | ticket URL / related docs |
 | Checklist | check only mechanically verifiable items (leave human items like reviewer assignment unchecked) |

--- a/claude/skills/commit-push-branch/SKILL.md
+++ b/claude/skills/commit-push-branch/SKILL.md
@@ -171,9 +171,30 @@ Applies **only when loop-mode is explicitly specified** at invocation time (basi
 - The branch name / commit message in Steps 3-6 are decided automatically from conventions and past style, with no user confirmation
 - **WIP squash applicability check (mechanical execution)**: if `wip(<stage>):` commits are stacked on the working branch (dev-cycle's stage-boundary WIP commits), always run `git ls-remote --heads origin <branch>` before squashing; **only if the output is empty (= unpushed)** proceed to run `git reset --soft $(git merge-base HEAD origin/<default-branch>)` to return all changes to staged, then create the single conventional commit (never use `--hard`). In this case, Step 5's explicit add is reinterpreted as "confirm via `git status` that the staged contents contain no secrets / out-of-scope files"
 - **Do not squash a branch already pushed by escalation**: rewriting pushed history would require a force push, which conflicts with the ban. Stack the final commit on top of the wip commits and push as-is (fast-forward). The wip commits remain visible in the PR's commit list, but the default branch stays clean because of the squash-merge convention
-- After the push in Step 7, **create a draft PR**: `gh pr create --draft` (title = commit title, body = the implementation plan / DoD check results / review results passed from the caller)
+- After the push in Step 7, **create a draft PR**: `gh pr create --draft` (title = commit title, body = assembled per the "PR body construction rules" below)
 - Never promote the draft (remove draft status) or merge
 - Interactive behavior without loop-mode is unchanged (PR creation only after user instruction)
+
+### PR body construction rules (loop-mode)
+
+Materials passed from the caller (dev-cycle) = implementation plan / DoD check results / spec deviations (SD#) / impact scope / self-review & security-review results (including perspective completion status) / ticket URL. Turn these into the body with the following rules:
+
+1. **Look for the target repo's PR template**: the first one found in the order `.github/pull_request_template.md` → `.github/PULL_REQUEST_TEMPLATE.md` → `PULL_REQUEST_TEMPLATE.md` → `docs/pull_request_template.md`
+2. **If a template exists, follow its section structure**: delete the HTML comment hints (`<!-- ... -->`) and fill each section with the corresponding material. Section names vary by repo, so map by meaning (guideline):
+
+| template section (example) | material to fill in |
+|---|---|
+| Summary / Changes | summary of the implementation plan / what changed |
+| Spec compliance | each DoD item ↔ its implementation & tests (check results) |
+| Spec deviations | SD# ("none" if there are none) |
+| Impact scope | changed symbol → referencing-site mapping and impact classification |
+| Verification | test / lint run results + self-review & security-review results (including perspective completion status) |
+| References | ticket URL / related docs |
+| Checklist | check only mechanically verifiable items (leave human items like reviewer assignment unchecked) |
+
+   If some material has no matching section in the template, append a section at the end of the body and record it in full (never drop it silently)
+3. **If there is no template, generate the default skeleton**: the 6 sections `## Summary` / `## Spec compliance` / `## Spec deviations` / `## Impact scope` / `## Verification` / `## References`
+4. **Branch ticket handling on repo visibility** (mechanically judged via `gh repo view --json visibility`): for a private repo, put the ticket URL in References (review-loop relies on "PR body + the ticket it references" as the spec). **For a public repo, never write internal URLs / the ticket body** (same spirit as the improve-harness iron rule — reference insights / tickets by name or ID only)
 
 ## Iron rules
 


### PR DESCRIPTION
## Summary
- commit-push-branch loop-mode now defines the actual PR body construction rules that dev-cycle references — dev-cycle.md's "template defined on the commit-push-branch side" was a dangling reference (the body format existed only as "whatever the caller passed")
- rules: look up the target repo's PR template (`.github/pull_request_template.md` → `.github/PULL_REQUEST_TEMPLATE.md` → root → `docs/`), map the caller's materials (implementation plan / DoD check results / SD# / impact scope / self-review & security-review results / ticket URL) onto its sections **by meaning**, append sections for unmatched materials (never drop silently); fall back to a fixed 6-section skeleton when no template exists
- ticket handling branches on repo visibility (`gh repo view --json visibility`): private → ticket URL goes in References (review-loop reads "PR body + referenced ticket" as the spec); public → no internal URLs / ticket bodies (same spirit as the improve-harness iron rule)
- ja SoT + en mirror updated in lockstep

## Validation (fresh session)
- run a loop-mode dev-cycle against a repo **with** a PR template → the draft PR body lands in the template's sections with comment hints removed = DoD
- same against a repo **without** a template → 6-section default skeleton
- public-repo case → no ticket URL / internal URL in the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)