### PR TITLE
:sparkles: add pr-follow-loop driver skill for shepherding authored PRs

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -49,6 +49,7 @@
 - 例外として許可: `commit-push-branch` (loop-mode 拡張) 経由の feature branch push + **draft PR 作成**
 - improve-harness (knowledge loop) も同例外を使える: harness 改善の draft PR 作成まで (対象 repo は dotfiles のみ)
 - review-loop も同例外を使える: watch 対象 PR への **review comment 投稿**まで (approve / request-changes / merge は引き続き人間のみ)
+- pr-follow-loop も同例外を使える: 自 author PR の bot 指摘 **triage の提示** (idempotency marker comment を含む) + **merge 後の自 worktree / merge 済 local branch の自動掃除**まで (bot 指摘の修正適用・decline 返信は人間承認後の対話で行い、approve / request-changes / merge は引き続き人間のみ)
 - 引き続き禁止: merge / draft の本 PR 化 / main への直 push / 新規 dependency 追加 / 破壊的操作 / 外部送信の有効化 — 検出したら escalation (ticket コメント + 通知 + WIP branch push) して停止
 - 安全装置 (hooks / permission deny / least privilege) は loop-mode でも一切緩めない
 - superpowers 棲み分け: 自律 pipeline (dev loop) では superpowers の process skill を使わない (背骨は自前 skill)。対話 session での brainstorming / TDD 参照は可

--- a/claude/ja/skills/pr-follow-loop/SKILL.md
+++ b/claude/ja/skills/pr-follow-loop/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pr-follow-loop
+description: /loop で回す「自分が author の open PR を見届ける」driver skill。1 tick = 自分の open PR を poll → 各 PR の段階を 1 歩進める（bot review 指摘の triage 提示 / human approve の watch / merge 後の自動掃除）→ 通知 → ScheduleWakeup で self-pace。「pr-follow-loop の tick を実行して」「PR 見届け loop 回して」等で使う（通常は /loop 経由）。dev-loop（PR を作る）/ review-loop（他人の PR をレビューする）の兄弟で、本 skill は自分が作った PR のその後を追う。
+---
+
+> **Source of truth:** 本ファイル（日本語）。更新時は本ファイルを先に直し、英訳（`claude/skills/pr-follow-loop/SKILL.md`）に反映する。
+
+# pr-follow-loop
+
+PR 見届けの driver（dev-loop / review-loop の兄弟）。**loop の lifecycle は user の /loop 操作が管理し、本 skill は 1 tick の内部を定義する。** 1 tick = 1 poll + 1 PR を最大 1 歩。
+
+三兄弟の棲み分け:
+- **dev-loop** = 自分が PR を「作る」（work-intake → dev-cycle → draft PR）
+- **review-loop** = 他人の PR を「レビューする」（review-requested:@me → 中立コメント）
+- **pr-follow-loop**（本 skill）= 自分が author の PR を「見届ける」（open 後の bot 指摘対応 → approve 待ち → merge 後の掃除）
+
+## 適用条件
+
+- /loop 起動（dynamic pacing）を前提（手動単発 tick も可）
+- 対象 repo の cwd / `gh` 認証済の local session
+- **設定は hardcode しない**: triage 対象の bot reviewer（例: CodeRabbit）/ merge をブロックする必須 human reviewer / 対象 repo は、project の reference memory（MEMORY.md）から取得する。未登録なら「reference memory 未登録」と明示し、user に確認してから登録・継続。skill 本体に repo 名 / bot 名 / メンバー名を焼かない
+
+## 手順（1 tick）
+
+### Step 1: precondition check
+
+- `date '+%Y-%m-%d %H:%M %Z'` で現地時刻を取得（tick report 用、時刻は推測しない）
+- git repo 内 / `gh auth status` が通ること
+
+### Step 2: poll（機械的）
+
+```bash
+gh pr list --author @me --state open \
+  --json number,headRefOid,title,isDraft,url,createdAt
+```
+
+- 対象 = **自分が author の open PR**（draft 含む）。段階 a / b はこの list から進める
+- merge 済 PR は `--state open` に出ないため、掃除（段階 c）の起点は別に持つ: **local の `.claude/worktrees/` 配下 worktree を列挙し、その branch の PR が merge 済か**を `gh pr list --author @me --state merged` / `gh pr view <branch>` で突き合わせる（stateless、cross-tick state を持たない）
+- open PR も merge 済 worktree も無ければ Step 4（idle）へ
+
+### Step 3: 段階判定と 1 歩（idempotency marker `<!-- pr-follow: <head-sha> -->`）
+
+poll で拾った PR から 1 件選び（oldest created 優先）、現在の段階に応じて **1 歩だけ**進める:
+
+#### a. bot 新指摘あり（現 head sha に未 triage の bot review）
+
+- bot reviewer の review / inline comment を取得し、**各指摘を repo 規約（`.claude/rules/`）に照らして assess**: 妥当（fix 推奨）/ 誤検知（false-positive）/ 規約衝突・YAGNI（decline 推奨）を、severity と 1 行理由付きで判定
+- **triage サマリ（各指摘 → verdict + 理由 + 推奨アクション）を提示し user に通知**。marker を記録して当該 head sha を triaged 扱いに
+- **loop はここまで**: 修正の適用（commit+push）・decline 返信は **user 承認後に対話で実施**（loop が独断で fix / decline しない）。設計判断・規約衝突は必ず escalation として明示
+- 判定に fresh context が要る規模なら review-lens 相当を subagent で spawn 可（ただし本 skill の役割は triage の提示までで、適用はしない）
+
+#### b. approve 待ち（未 triage 指摘なし・必須 reviewer 未 approve）
+
+- 近リアルタイム通知のため、当該 PR の review verdict（APPROVED / CHANGES_REQUESTED）を watch する Monitor を張る（既存なら重複起動しない。TaskList で確認）
+- verdict を検知したら `PushNotification` で通知（APPROVED だけでなく CHANGES_REQUESTED も拾う＝無言で待ち続けない）
+
+#### c. merged（`.claude/worktrees/` の worktree に対応する PR が MERGED）
+
+- 起点は Step 2 の突き合わせ: local worktree が残っているのに対応 PR が merge 済のものを対象にする
+- **自動掃除**（事後報告）:
+  1. 対象 worktree の `git status --porcelain` が空（clean）であることを確認。**dirty なら掃除せず escalation**（uncommitted 変更の喪失を防ぐ）
+  2. clean なら `git worktree remove <path>` + **merge 済 local branch を削除**
+  3. **remote branch と他の worktree は触らない**（merge 時の GitHub auto-delete に委ねる。remote 削除は outward action で本 skill の範囲外）
+- 掃除結果を通知（受領確認: worktree list から消滅・branch list から消滅を機械確認）
+
+### Step 4: self-pacing（`ScheduleWakeup`）
+
+| 直前の結果 | 次 wakeup | 理由 |
+|---|---|---|
+| 1 歩進んだ（triage 提示 / 掃除完了） | 60-120s | drain — 次の PR / 次段階を即消化 |
+| approve 待ちに移行 | 1200-1800s | Monitor が主 signal、これは fallback heartbeat |
+| 該当なし（0 件 or 全 skip） | 1200-1800s | idle（20-30 分） |
+| error | 900s | retry 間隔 |
+
+- **連続エラー breaker**: tick が **3 連続**で error したら wakeup を停止（`ScheduleWakeup` stop）、「loop 停止（3 連続 error）」を通知して終了。成功でリセット
+
+### Step 5: tick report（強制出力）
+
+```
+## pr-follow-loop tick report
+- time: <現地時刻> — previous tick: <前 report の時刻 / unknown>
+- poll: <N> PR（自分 author, open）
+- action: [none / PR #<n> <stage: bot-triage 提示 / approve-watch 起動 / cleanup 完了>] — receipts: <triage 通知 / Monitor task id / 掃除後の worktree・branch 消滅確認>
+- notification: [sent / skipped (terminal active — normal) / not delivered / n/a]
+- error streak: <n>/3
+- next wakeup: <秒>（~<HH:MM> / <理由>）
+```
+
+## 鉄則
+
+1. **approve / request-changes / merge は人間のみ** — loop は GitHub の review state を操作しない
+2. **bot 指摘は triage の提示まで** — 修正適用・decline 返信は user 承認後に対話で実施。loop が独断で fix / decline しない
+3. **掃除は clean 確認必須** — dirty worktree は掃除せず escalation。掃除対象は自 worktree + merge 済 local branch のみ（remote / 他 worktree は不変）
+4. **通知は receipts の実在確認後** — triage 通知・掃除後の消滅・Monitor 起動を機械確認してから報告
+5. **設定を hardcode しない** — bot 名 / 必須 reviewer / repo は reference memory から取得
+6. **tick report を省略しない** — 全項目を毎 tick 出力
+7. **安全装置を緩めない** — hooks / permission deny / least privilege は loop でも一切緩めない

--- a/claude/skills/pr-follow-loop/SKILL.md
+++ b/claude/skills/pr-follow-loop/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pr-follow-loop
+description: Driver skill run via /loop that shepherds the open PRs I authored. 1 tick = poll my open PRs → advance one PR by one step (triage-and-present bot review findings / watch for human approval / auto-clean up after merge) → notify → ScheduleWakeup to self-pace. Use for 「pr-follow-loop の tick を実行して」("run the pr-follow-loop tick"), 「PR 見届け loop 回して」("run the PR follow loop"), etc. (normally via /loop). Sibling of dev-loop (produces PRs) and review-loop (reviews others' PRs); this skill follows the PRs I produced through the rest of their life.
+---
+
+> **Source of truth:** `claude/ja/skills/pr-follow-loop/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# pr-follow-loop
+
+The driver for shepherding PRs (sibling of dev-loop / review-loop). **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most one step on one PR.
+
+The three siblings:
+- **dev-loop** = I **produce** PRs (work-intake → dev-cycle → draft PR)
+- **review-loop** = I **review others'** PRs (review-requested:@me → neutral comment)
+- **pr-follow-loop** (this skill) = I **shepherd my own** PRs (handle bot findings after open → wait for approval → clean up after merge)
+
+## Applicability conditions
+
+- Startup from /loop (dynamic pacing) is assumed (a single manual tick is also fine)
+- A local session with the target repo's cwd / `gh` authenticated
+- **Do not hardcode configuration**: the bot reviewers to triage (e.g. CodeRabbit) / the required human reviewer(s) that gate merge / the target repo are obtained from the project's reference memory (MEMORY.md). If not registered, state "reference memory not registered", confirm with the user, register it, and continue. Never bake repo names / bot names / member names into the skill
+
+## Procedure (1 tick)
+
+### Step 1: precondition check
+
+- Run `date '+%Y-%m-%d %H:%M %Z'` for the current local time (for the tick report; never guess the time)
+- Must be inside a git repo / `gh auth status` must pass
+
+### Step 2: poll (mechanical)
+
+```bash
+gh pr list --author @me --state open \
+  --json number,headRefOid,title,isDraft,url,createdAt
+```
+
+- The target is **open PRs I authored** (drafts included). Stages a / b advance from this list
+- Merged PRs do not appear under `--state open`, so the trigger for cleanup (stage c) is held separately: **enumerate local worktrees under `.claude/worktrees/` and cross-check whether each one's branch has a merged PR** via `gh pr list --author @me --state merged` / `gh pr view <branch>` (stateless — no cross-tick state)
+- If there are neither open PRs nor merged-but-still-present worktrees, go to Step 4 (idle)
+
+### Step 3: stage detection and one step (idempotency marker `<!-- pr-follow: <head-sha> -->`)
+
+Select one PR from the poll (oldest created first) and, based on its current stage, advance it by **exactly one step**:
+
+#### a. New bot findings (un-triaged bot review on the current head sha)
+
+- Fetch the bot reviewer's reviews / inline comments and **assess each finding against the repo conventions (`.claude/rules/`)**: valid (recommend fix) / false-positive / convention-conflict or YAGNI (recommend decline), each with a severity and a one-line reason
+- **Present the triage summary (each finding → verdict + reason + recommended action) and notify the user.** Record the marker to treat this head sha as triaged
+- **The loop stops here**: applying fixes (commit+push) / posting decline replies happen **after the user approves, in dialogue** (the loop never fixes / declines on its own). Design judgments / convention conflicts are always surfaced as escalation
+- If the assessment needs fresh context at scale, a review-lens-equivalent may be spawned as a subagent (but this skill's role ends at presenting the triage — it does not apply anything)
+
+#### b. Awaiting approval (no un-triaged findings; required reviewer has not approved)
+
+- For near-real-time notification, arm a Monitor that watches the PR's review verdict (APPROVED / CHANGES_REQUESTED) (do not double-arm if one already runs — check via TaskList)
+- On a detected verdict, notify via `PushNotification` (catch CHANGES_REQUESTED as well as APPROVED — do not sit in silence)
+
+#### c. Merged (a worktree under `.claude/worktrees/` whose PR is MERGED)
+
+- The trigger comes from the Step 2 cross-check: a local worktree that still exists while its corresponding PR is already merged
+- **Auto-cleanup** (report after the fact):
+  1. Confirm the target worktree's `git status --porcelain` is empty (clean). **If dirty, do not clean up — escalate** (to avoid losing uncommitted changes)
+  2. If clean, `git worktree remove <path>` + **delete the merged local branch**
+  3. **Do not touch the remote branch or other worktrees** (leave remote deletion to GitHub's auto-delete on merge; deleting the remote is an outward action outside this skill's scope)
+- Notify the cleanup result (receipts: mechanically confirm the worktree is gone from `git worktree list` and the branch is gone from the branch list)
+
+### Step 4: self-pacing (`ScheduleWakeup`)
+
+| Immediately preceding result | Next wakeup | Reason |
+|---|---|---|
+| advanced one step (triage presented / cleanup done) | 60-120s | drain — consume the next PR / next stage right away |
+| moved to awaiting-approval | 1200-1800s | Monitor is the primary signal; this is the fallback heartbeat |
+| none applicable (0 or all skipped) | 1200-1800s | idle (20-30 min) |
+| error | 900s | retry interval |
+
+- **Consecutive-error breaker**: if a tick errors **3 consecutive** times, stop the wakeup (`ScheduleWakeup` stop), notify "loop stopped (3 consecutive errors)", and terminate. Resets on success
+
+### Step 5: tick report (forced output)
+
+```
+## pr-follow-loop tick report
+- time: <current local time> — previous tick: <time from previous report / unknown>
+- poll: <N> PRs (mine, open)
+- action: [none / PR #<n> <stage: bot-triage presented / approve-watch armed / cleanup done>] — receipts: <triage notification / Monitor task id / post-cleanup worktree+branch removal confirmation>
+- notification: [sent / skipped (terminal active — normal) / not delivered / n/a]
+- error streak: <n>/3
+- next wakeup: <seconds> (~<HH:MM> / <reason>)
+```
+
+## Iron rules
+
+1. **Approve / request-changes / merge are the human's only** — the loop never operates GitHub's review state
+2. **Bot findings go only as far as presenting the triage** — applying fixes / posting decline replies happen after the user approves, in dialogue. The loop never fixes / declines on its own
+3. **Cleanup requires a clean check** — a dirty worktree is not cleaned; escalate instead. Cleanup targets are the own worktree + the merged local branch only (remote / other worktrees are left untouched)
+4. **Notify only after verifying the receipts exist** — mechanically confirm the triage notification / the removal / the Monitor start before reporting
+5. **Do not hardcode configuration** — bot names / required reviewers / repo come from the reference memory
+6. **Do not omit the tick report** — output all items every tick
+7. **Do not loosen the safety devices** — hooks / permission deny / least privilege are never relaxed in the loop


### PR DESCRIPTION
## What
Add `pr-follow-loop`, the third sibling driver skill (peer to dev-loop / review-loop), run via /loop. It shepherds the open PRs I authored through the rest of their lifecycle.

- **dev-loop** produces PRs, **review-loop** reviews others' PRs, **pr-follow-loop** follows my own PRs.

## 1 tick
Poll `gh pr list --author @me` → advance one PR by one step:

- **bot findings**: triage each finding against `.claude/rules/` (fix / decline + reason, with severity) → present the summary + notify. Applying fixes / posting decline replies happen after human approval in dialogue — the loop never fixes or declines on its own.
- **awaiting approval**: arm a Monitor for the review verdict → notify on APPROVED / CHANGES_REQUESTED.
- **merged**: cross-check local `.claude/worktrees/` against merged PRs → clean check → remove worktree + merged local branch (dirty → escalate; remote / other worktrees untouched) → report after the fact.

## Guardrails
- approve / request-changes / merge remain human-only.
- bot names / required reviewers / repo are not hardcoded — read from the project's reference memory.
- consecutive-error breaker; safety devices (hooks / permission deny / least privilege) never relaxed.

## Files
- `claude/ja/skills/pr-follow-loop/SKILL.md` (Japanese source of truth)
- `claude/skills/pr-follow-loop/SKILL.md` (English translation)
- `claude/CLAUDE.md` — loop-mode exception line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
