### PR TITLE
:sparkles: add cowork design skills for spec hardening and implementation planning

### DIFF
--- a/claude/cowork-skills/README.md
+++ b/claude/cowork-skills/README.md
@@ -1,0 +1,35 @@
+# claude/cowork-skills — cowork 用 skill (claude.ai account 配布)
+
+設計工程を担う cowork 用 skill の authoring SoT。日本語原文は `claude/ja/cowork-skills/` (更新は ja → 英訳の順、`claude/ja/README.md` の規約に従う)。
+
+## `claude/skills/` と分けている理由
+
+- `claude/skills/` は `~/.claude/skills` に symlink される (Makefile) ため、置いたものは **Claude Code に載る**
+- cowork session は `~/.claude/skills/` も repo の `.claude/skills/` も読まない。**claude.ai account で有効化された skill を session 開始時に sync する**
+- 本 directory の skill は設計工程 (cowork) 専用で、Claude Code 側の着手ゲート (`/spec-check`) と責務が重ならないよう local には load させない
+
+## 配布手順
+
+1. ja 原文を更新 → 英訳を本 directory に反映
+2. skill directory を **ZIP の root に置いて** 固める (file を直に ZIP root へ置くのは誤り)
+   ```sh
+   cd claude/cowork-skills && zip -r ../../harden-spec.zip harden-spec
+   ```
+3. Mac の Claude desktop app の Customize sidebar (または claude.ai の skill 設定) から upload して有効化
+4. cowork session を開き直す (skill は session 開始時に sync される)
+
+自動 sync 経路は無いので、本 repo と claude.ai 側の drift は手運用で受ける。
+
+## 制約
+
+- frontmatter の上限: `name` 64 文字 / `description` 200 文字。**発火条件を description に詰め込まない** (本文冒頭の「発火条件」節に置く)
+- account 単位で全 cowork session に載るため、project 固有語 (repo 名 / service 名 / ticket prefix / 環境 URL) を hardcode しない
+- 観点の SoT は対象 repo 側の `.claude/rules/` に置き、skill 本文からは path で参照する。repo 側に無い場合の fallback は各 skill の `references/` に汎用版を持つ
+- cowork は working tree しか読めない。`git` / `gh` に依存する手順を書かない
+
+## skill 一覧
+
+| skill | 責務 |
+|---|---|
+| `harden-spec` | 設計 draft / ticket を repo と突き合わせ、実装可能な spec にする (設計判断はしない) |
+| `plan-implementation` | 確定 spec を層配置 → PR 分割 → 着手手順に落とす (実装はしない) |

--- a/claude/cowork-skills/harden-spec/SKILL.md
+++ b/claude/cowork-skills/harden-spec/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: harden-spec
+description: Cross-checks a design draft / ticket against the repo to make it implementable: 5 drift classes + data model minimization, open decisions returned with a recommendation. Working tree only. 「spec 詰めて」
+---
+
+> **Source of truth:** `claude/ja/cowork-skills/harden-spec/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# harden-spec
+
+Takes a design draft / ticket a human wrote and turns it into an **implementable spec** by cross-checking it against what the repo actually contains.
+
+**Makes no design decisions.** Open decisions go back to the human with options + a recommendation + the rationale. Doesn't produce an implementation plan either (that's `plan-implementation`).
+
+Boundary with `write-spec`: that skill fills the holes in the spec contract (are the required sections present). This skill checks the spec **against the repo's reality** (does what's written hold in the repo).
+
+## Trigger
+
+Default-on. If skipping, output the reason.
+
+- Requests like 「spec を詰めて」「実装可能にして」「設計を repo と突き合わせて」
+- A ticket / design draft is in the input and the target repo is open
+
+## Assumptions
+
+- **Reads the working tree only.** Doesn't depend on `git` / `gh` / branches / diffs. Conflict detection against in-flight PRs / branches is out of scope (it lives in `/spec-check` on the Claude Code side)
+- The SoT for the perspectives is `.claude/rules/spec-drift.md` in the repo. **Read it first**
+- If the spec touches the data model, also read `.claude/rules/data-modeling.md`
+- If neither exists in the repo: fall back to the generic version in `references/portable-checklist.md` and state explicitly that it ran without the repo-specific perspectives
+
+## Procedure
+
+1. **List the spec's literals** — identifiers / paths / citations / columns and fields / commands
+2. **Resolve them against the repo** — grep each one. Unresolved ones are drift candidates
+3. **Judge every drift class** — output found / none + what was checked **for every class** (no silent skips)
+4. **Data model minimization** — for any proposed new persisted state, apply derive > tighten an existing column > add a column, in that order
+5. **Surface the open decisions** — present options + one recommendation + the rationale, then wait for the human's decision
+6. **Write the decisions back** into the spec body. Keep the rejected options and why, so the same discussion doesn't reopen
+
+## Output
+
+- Per drift finding: class / evidence on both sides (repo side as path + symbol or heading, spec side as the section heading + the quoted sentence) / why it is drift / proposed resolution
+- The list of open decisions: options, recommendation, rationale
+- A final verdict on whether it is implementable. **Don't set the ready flag** (humans only)
+
+## Don't
+
+- Settle design decisions unilaterally, set the ready flag, commit / push
+- Detect conflicts with in-flight PRs / branches (`/spec-check`'s job)
+- Produce layer placement / PR splits / step-by-step plans (`plan-implementation`'s job)
+- Cite by line number (they go stale — point at path + symbol or heading)

--- a/claude/cowork-skills/harden-spec/references/portable-checklist.md
+++ b/claude/cowork-skills/harden-spec/references/portable-checklist.md
@@ -1,0 +1,27 @@
+# Generic checklist (fallback when the repo has no perspective files)
+
+Use this only when the repo has no `.claude/rules/spec-drift.md` / `.claude/rules/data-modeling.md`. It contains no repo-specific paths or identifiers. When using it, state in the output that the run went without the repo-specific perspectives.
+
+## The 5 drift classes
+
+| # | Class | How to detect |
+|---|---|---|
+| D1 | Contradiction inside the spec | Per entity (column / field / endpoint / ordering / failure mode), collect the normative statements and compare them pairwise. They cluster around entities that appear in more than one section |
+| D2 | spec ↔ implementation | Grep every identifier the spec names (type / function / column / field / env var / task). For each miss, decide and state whether it is genuinely new or a wrong name |
+| D3 | spec ↔ SoT doc | Read the certainty markers of the docs in the change area at both the whole-doc and section level. A spec that depends on an unsettled section must name that dependency and get it confirmed |
+| D4 | Citation that doesn't resolve in the repo | Resolve every citation to a path plus heading. An unresolvable citation is not evidence — replace it with the repo's literal or drop it |
+| D5 | The thing already exists | Before accepting any "add X", grep the existing surface: schema / API definitions / error definitions / config files |
+
+Recurring D1 shapes: "behavior unchanged / existing tests stay green" coexisting with a newly specified internal behavior on the same code path; a DoD example table whose expected values the design body's algorithm can't produce; a DoD item requiring something the non-goals exclude.
+
+When docs contradict each other, don't rank them by doc type — find the SoT declaration inside the docs themselves and follow it. If there is none, escalate to a human.
+
+## Data model minimization
+
+Order of preference: **derive > tighten an existing column > add a column**.
+
+- Suspect the new column first. Can it be derived from existing state (a timestamp, the presence of a row, an existing enum)?
+- Tighten an existing column to a single meaning instead of adding a second overlapping column
+- Reduce the design to one invariant and derive per-case behavior from it
+- Treat "we can't drop existing data" as a question, not a settled constraint. Running a destructive migration is a human's call and needs dry-run / blast radius / rollback
+- Record the rejected shape and the reason

--- a/claude/cowork-skills/plan-implementation/SKILL.md
+++ b/claude/cowork-skills/plan-implementation/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: plan-implementation
+description: Turns a settled spec into an implementation plan: layer placement, PR split, junior-followable steps with pitfalls and local verification. Working tree only. 「実装計画にして」「PR 分割して」
+---
+
+> **Source of truth:** `claude/ja/cowork-skills/plan-implementation/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# plan-implementation
+
+Turns a settled spec into a plan an implementer can start on without hesitating.
+
+**Doesn't implement.** Doesn't change the spec's design decisions either (on finding a contradiction, report it and stop).
+
+## Trigger
+
+Default-on. If skipping, output the reason.
+
+- Requests like 「実装計画にして」「PR 分割して」「着手手順を出して」
+- A spec the human has declared accepted is in the input
+
+If an unsettled spec arrives, don't run this skill — point at `harden-spec` first (the two don't overlap).
+
+## Assumptions
+
+- **Reads the working tree only.** Doesn't depend on `git` / `gh`
+- The criteria for layer placement live in the repo's `.claude/rules/layering.md`; the PR size guideline and the doc-colocation convention live in `.claude/rules/review-checklist.md`. **Read those first**
+- If they don't exist in the repo: fall back to the generic version in `references/portable-planning.md` and state explicitly that it ran without the repo-specific layer conventions
+
+## Procedure
+
+1. **Layer placement** — assign each change to a layer. For each layer, **name one existing example file and confirm it exists by grep**
+2. **Order by dependency** — the referenced side first. If it cycles, change how the split is cut
+3. **Split into PRs** — cut by dependency order / the size guideline / the doc-colocation convention. 1 PR = 1 responsibility
+4. **Steps per PR** — files to touch, tests to add, pitfalls, local verification commands
+5. **Confirm the verification means exist** — grep the repo's task definition files for every task / test command named. **Don't write a command that doesn't exist**
+
+## Output
+
+- The PR list: order / purpose / files touched / expected line count
+- Per PR: steps at a granularity a junior can follow / pitfalls / local verification commands
+- Spec items that couldn't be turned into a plan, called out as open questions (don't drop them silently)
+
+## Don't
+
+- Implement / commit / push
+- Change the spec's design decisions (report contradictions and stop)
+- Detect conflicts with in-flight PRs / branches (`/spec-check`'s job on the Claude Code side)
+- Put commands or file paths into the plan without confirming they exist

--- a/claude/cowork-skills/plan-implementation/references/portable-planning.md
+++ b/claude/cowork-skills/plan-implementation/references/portable-planning.md
@@ -1,0 +1,28 @@
+# Generic planning perspectives (fallback when the repo has no layer-convention files)
+
+Use this only when the repo has no `.claude/rules/layering.md` / `.claude/rules/review-checklist.md`. When using it, state in the output that the run went without the repo-specific layer conventions.
+
+## Layer placement
+
+- Establish the dependency direction first (which layer imports which). If it isn't readable, grep the imports of three existing files to infer it and state that it is an inference
+- Put new symbols **next to the existing files of the same kind**. Before creating a new layer or package, write down why the existing location isn't enough
+- Create a replacement seam only when it's needed, as a minimal interface on the consumer side. Don't pre-build an interface with a single use site
+
+## Dependency order
+
+- Implement the referenced side first (leaves → callers)
+- If it cycles, change how the PRs are cut (split the shared part out first)
+
+## PR split
+
+- 1 PR = 1 responsibility. Cut when it exceeds the size guideline (if the repo states none, use 800 lines as a stated provisional value)
+- Cutting lines: layer / responsibility / stage (foundation → wiring) / file type
+- Colocate the corresponding doc update in the same PR. File an issue for any discrepancy this PR can't fix and link it from the PR
+- A PR of only new, unreferenced files (foundation only) is acceptable. Don't invert the stack order against the dependency order
+
+## Granularity of the steps
+
+- List the files to touch by path, one per line
+- Order them test-first (failing test → implementation → green)
+- Pitfalls: constraints hit before / vendor-specific quirks / places where generated artifacts must be regenerated
+- Local verification commands must **exist in the repo's task definition files**. If there are none, write "no verification means" (don't instruct anyone to create one)

--- a/claude/ja/README.md
+++ b/claude/ja/README.md
@@ -1,7 +1,9 @@
 # claude/ja — 日本語原文 (source of truth)
 
-`claude/skills/` / `claude/agents/` の **日本語原文** を同じ階層構造で保持する。
-実際に model が読む live ファイル (`claude/skills/`, `claude/agents/`) は英語版。
+`claude/skills/` / `claude/agents/` / `claude/cowork-skills/` の **日本語原文** を同じ階層構造で保持する。
+実際に model が読む live ファイル (`claude/skills/`, `claude/agents/`, `claude/cowork-skills/`) は英語版。
+
+`claude/cowork-skills/` は Claude Code に load されず、claude.ai account へ ZIP upload して cowork session で使う (配布手順は `claude/cowork-skills/README.md`)。
 
 ## 更新手順 (必ずこの順番)
 

--- a/claude/ja/cowork-skills/harden-spec/SKILL.md
+++ b/claude/ja/cowork-skills/harden-spec/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: harden-spec
+description: 設計 draft / ticket を repo と 3 者照合して実装可能な spec にする。乖離 5 分類 + data model 最小化を当て、未決は選択肢と推奨を付けて人間に返す。working tree のみ読む。「spec 詰めて」「実装可能にして」等で使う。
+---
+
+# harden-spec
+
+人間が書いた設計 draft / ticket を、repo の実態と突き合わせて **実装可能な spec** にする。
+
+**設計判断はしない。** 未決は選択肢 + 推奨 + 根拠を出して人間に返す。実装計画も作らない (`plan-implementation` の責務)。
+
+`write-spec` との境界: あちらは spec contract の穴埋め (必須 section が揃っているか)。本 skill は **repo の実態との突合** (書かれていることが repo で成立するか)。
+
+## 発火条件
+
+default-on。skip する場合は理由を出力する。
+
+- 「spec を詰めて」「実装可能にして」「設計を repo と突き合わせて」等の要求
+- ticket / 設計 draft の本文が入力にあり、対象 repo が開かれている
+
+## 前提
+
+- **working tree しか読まない。** `git` / `gh` / branch / diff に依存しない。進行中 PR / branch との衝突検出は本 skill の責務外 (Claude Code の `/spec-check` 側)
+- 観点の SoT は repo 側の `.claude/rules/spec-drift.md`。**最初にこれを読む**
+- data model に触る spec なら `.claude/rules/data-modeling.md` も読む
+- どちらも無い repo の場合: `references/portable-checklist.md` の汎用版に落として続行し、「repo 固有の観点なしで実施」と明示する
+
+## 手順
+
+1. **spec の literal を一覧化** — 識別子 / path / 引用 / 列・field / コマンド
+2. **repo に解決** — 各 literal を grep する。未解決は乖離候補
+3. **乖離を全分類で判定** — 検出あり / なし + 何を確認したかを **全分類について出力する** (黙った skip 禁止)
+4. **data model 最小化** — 新規の永続状態の提案があれば、導出 > 既存列の意味を締める > 列追加 の順で当てる
+5. **未決の洗い出し** — 選択肢 + 推奨 1 つ + 根拠を提示し、人間の決定を待つ
+6. **本文反映** — 決定を spec 本文に書き戻す。却下した案と理由も残す (同じ議論の再燃を防ぐ)
+
+## 出力
+
+- 乖離 1 件ごと: 分類 / 両側の evidence (repo 側は path + symbol または見出し、spec 側は section 見出し + 原文引用) / なぜ乖離か / 解消案
+- 未決一覧: 選択肢・推奨・根拠
+- 最後に実装可能かの判定。**ready flag は立てない** (人間のみ)
+
+## やらないこと
+
+- 設計判断の独断、ready flag、commit / push
+- 進行中 PR / branch との衝突検出 (`/spec-check` 側)
+- 実装配置 / PR 分割 / 着手手順 (`plan-implementation` 側)
+- line 番号での引用 (stale する。path + symbol または見出しで指す)

--- a/claude/ja/cowork-skills/harden-spec/references/portable-checklist.md
+++ b/claude/ja/cowork-skills/harden-spec/references/portable-checklist.md
@@ -1,0 +1,27 @@
+# 汎用版 checklist (repo に観点 file が無い場合の fallback)
+
+repo 側に `.claude/rules/spec-drift.md` / `.claude/rules/data-modeling.md` が無いときだけ使う。repo 固有の path / 識別子を含まない汎用形。使用時は「repo 固有の観点なしで実施」と出力に明示する。
+
+## 乖離 5 分類
+
+| # | 分類 | 検出手順 |
+|---|---|---|
+| D1 | spec 内部の矛盾 | entity (列 / field / endpoint / 順序 / failure mode) ごとに規範的記述を集め総当たりで突合。複数 section に登場する entity に集中する |
+| D2 | spec ↔ 実装 | spec が挙げる識別子 (型 / 関数 / 列 / field / 環境変数 / task) を全て grep。hit しないものは「本当に新規」か「名前違い」のどちらかを判定して明示 |
+| D3 | spec ↔ SoT doc | 変更領域の doc の確定度表記を doc 全体・section 単位の両方で読む。未確定 section に依存する spec は依存を名指しして確認を取る |
+| D4 | 出典が repo に無い引用 | 全ての引用を path + 見出しに解決する。解決できない引用は根拠ではない (repo の literal に置換 or 削除) |
+| D5 | 既存の見落とし | 「X を追加」を受け入れる前に、schema / API 定義 / error 定義 / 設定 file の既存面を grep する |
+
+D1 の頻出パターン: 「挙動不変 / 既存 test はそのまま green」と同一 code path への新しい内部挙動指定の併存 / DoD の例表の期待値が設計本体の算法から出ない / non-goals が除外するものを DoD が要求。
+
+doc 同士が矛盾する場合は doc 種別で順位を付けず、doc 自身の SoT 宣言を探して従う。宣言が無ければ人間へ escalate。
+
+## data model 最小化
+
+優先順位は **導出 > 既存列の意味を締める > 列を足す**。
+
+- 新しい列をまず疑う。既存の状態 (timestamp / 行の存在 / 既存 enum) から導出できないか
+- 重なる 2 本目の列を足す代わりに、既存列の意味を 1 つに締める
+- 設計を不変条件 1 本に落とし、case ごとの挙動をそこから導出する
+- 「既存データは消せない」を前提ではなく問いとして扱う。破壊的 migration の実行は人間判断で、dry-run / 影響範囲 / 戻し方が要る
+- 却下した形と理由を記録する

--- a/claude/ja/cowork-skills/plan-implementation/SKILL.md
+++ b/claude/ja/cowork-skills/plan-implementation/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: plan-implementation
+description: 確定 spec を実装計画に落とす。層配置の判断 → PR 分割 (依存順 / 行数目安) → junior が追える手順 + ハマりどころ + 手元確認手段。working tree のみ読む。「実装計画にして」「PR 分割して」等で使う。
+---
+
+# plan-implementation
+
+確定済みの spec を、実装者が迷わず着手できる計画に落とす。
+
+**実装はしない。** spec の設計判断も変えない (矛盾を見つけたら報告して止まる)。
+
+## 発火条件
+
+default-on。skip する場合は理由を出力する。
+
+- 「実装計画にして」「PR 分割して」「着手手順を出して」等の要求
+- 人間が受け入れを表明済みの spec が入力にある
+
+未確定の spec が来た場合は本 skill を回さず、`harden-spec` を先に通すよう促す (兼務しない)。
+
+## 前提
+
+- **working tree しか読まない。** `git` / `gh` に依存しない
+- 層配置の判断基準は repo 側の `.claude/rules/layering.md`、PR 規模の目安と docs 同居の規約は `.claude/rules/review-checklist.md`。**先にこれらを読む**
+- 無い repo の場合: `references/portable-planning.md` の汎用版に落として続行し、「repo 固有の層規約なしで実施」と明示する
+
+## 手順
+
+1. **実装配置** — 変更を層に割り当てる。層ごとに **既存の実例 file を 1 つ挙げ、grep で実在を確認する**
+2. **依存順に並べる** — 参照される側を先に。循環したら分割の切り方を変える
+3. **PR 分割** — 依存順 / 行数目安 / docs 同居の規約で切る。1 PR = 1 責務
+4. **各 PR の着手手順** — 触る file、追加する test、ハマりどころ、手元確認コマンド
+5. **検証手段の実在確認** — 挙げた task / test コマンドを repo の task 定義 file で grep する。**実在しないコマンドは書かない**
+
+## 出力
+
+- PR 一覧: 順序 / 目的 / 触る file / 想定行数
+- PR ごと: 着手手順 (junior が追える粒度) / ハマりどころ / 手元確認コマンド
+- 計画に落とせなかった spec 項目を要確認事項として明示 (黙って落とさない)
+
+## やらないこと
+
+- 実装 / commit / push
+- spec の設計判断の変更 (矛盾は報告して停止)
+- 進行中 PR / branch との衝突検出 (Claude Code の `/spec-check` 側)
+- 実在確認していないコマンド・file path を計画に書くこと

--- a/claude/ja/cowork-skills/plan-implementation/references/portable-planning.md
+++ b/claude/ja/cowork-skills/plan-implementation/references/portable-planning.md
@@ -1,0 +1,28 @@
+# 汎用版 実装計画観点 (repo に層規約 file が無い場合の fallback)
+
+repo 側に `.claude/rules/layering.md` / `.claude/rules/review-checklist.md` が無いときだけ使う。使用時は「repo 固有の層規約なしで実施」と出力に明示する。
+
+## 実装配置
+
+- 依存方向を先に確定する (どの層がどの層を import するか)。方向が読めない場合は既存 file の import を 3 つ grep して推定し、推定であることを明示する
+- 新規 symbol は**既存の同種 file の隣**に置く。新しい階層・新しい package を作る前に、既存の置き場所で足りない理由を書く
+- 差し替え seam は必要になった時点で consumer 側に最小 interface で作る。使用箇所が 1 つの interface を先回りで作らない
+
+## 依存順
+
+- 参照される側を先に実装する (葉 → 利用側)
+- 循環したら PR の切り方を変える (共有部分を先に独立させる)
+
+## PR 分割
+
+- 1 PR = 1 責務。行数の目安を超えたら切る (目安が repo に無ければ 800 行を暫定値として明示)
+- 切り口: 層 / 責務 / 段階 (foundation → wiring) / file 種別
+- 対応する doc の更新は同 PR に同居させる。同 PR で直せない乖離は issue に切って PR から link する
+- 未参照の新規 file だけの PR (foundation only) は許容。stack 順序は依存の逆順にしない
+
+## 着手手順の粒度
+
+- 触る file を path で列挙する。1 file 1 行
+- test を先に書く順序で並べる (失敗する test → 実装 → green)
+- ハマりどころ: 過去に踏んだ制約 / vendor 固有の癖 / 生成物の再生成が要る箇所
+- 手元確認コマンドは **repo の task 定義 file に実在するものだけ**。無い場合は「確認手段なし」と書く (作れとは書かない)


### PR DESCRIPTION
## 概要

- 設計工程を cowork へ移管する方針の成果物 2。設計を詰める skill 2 本を追加
- 分担: **cowork = 設計を詰める** / **Claude Code = 着手可否のゲート**。cowork は working tree しか読めず `git` / `gh` が使えないため、進行中 PR との衝突検出だけを Claude Code 側 (`/spec-check`) に残す
- 観点の SoT は**対象 repo の `.claude/rules/`** に置き、skill 本文からは path 参照のみ (二重管理の回避)。
- 10 files +341/-2。`claude/ja/cowork-skills/` (SoT) と英訳 live を対で追加
- 安全装置は無変更: permission / hooks / escalation 条件 / 新規 dependency の壁 / merge・draft 本 PR 化の禁止

## 変更内容

| 対象 | 変更 |
|---|---|
| `claude/cowork-skills/harden-spec/` | 設計 draft / ticket を repo と 3 者照合して実装可能な spec にする skill。乖離 5 分類の全件判定 + data model 最小化 + 未決を選択肢と推奨で人間へ返す。設計判断・ready flag・実装計画は責務外 |
| `claude/cowork-skills/plan-implementation/` | 確定 spec を層配置 → 依存順 → PR 分割 → junior 手順に落とす skill。未確定 spec は `harden-spec` へ差し戻し兼務しない。挙げた確認コマンドの実在確認を手順に含める |
| 各 skill の `references/portable-*.md` | 対象 repo に `.claude/rules/` が無い場合の汎用版 fallback。使用時は「repo 固有の観点なしで実施」の明示を義務化 |
| `claude/cowork-skills/README.md` | 配布手順 (ZIP root の作り方 / desktop app から有効化 / 手動 sync の drift 受容) と制約 (frontmatter 上限 / 固有語 hardcode 禁止 / working tree のみ) |
| `claude/ja/README.md` | ja mirror の対象を 3 directory 体制に更新 (`skills` / `agents` / `cowork-skills`) |

## `claude/skills/` と分けた理由

- `claude/skills/` は Makefile で `~/.claude/skills` に symlink されるため、置くと **Claude Code に載る**
- cowork session は `~/.claude/skills/` も repo の `.claude/skills/` も読まず、**claude.ai account で有効化された skill を session 開始時に sync する** (配布は ZIP upload)
- local load させると設計工程 (cowork) と着手ゲート (`/spec-check`) の責務が重なるため分離

## 検証

- frontmatter 上限 (`name` 64 / `description` 200 文字) を実測: 英語版 199 / 176 文字、name 11 / 19。初版が 280 / 238 で超過していたため短縮済
- `zip -r` で実際に固めて ZIP root が `harden-spec/` になることを確認 (file を直に root へ置く誤りがないこと)
- project 固有語 (repo 名 / service 名 / ticket prefix / vendor 名) の混入 0 件 — account 単位で全 cowork session に載るための要件
- ja / live の構造 parity 確認 (差分は live 側のみの `README.md` で意図通り)

## 後続

- 成果物 3: Claude Code 側 `/spec-check` の references 拡張 (同じ rules を参照した再検証 + 進行中 PR / branch 衝突チェック)
- claude.ai への ZIP upload は merge 後に手運用
