### PR TITLE
:recycle: slim the harness — extract templates, consolidate loop rules, single-source skip conditions

### DIFF
--- a/claude/agents/code-refactor-advisor.md
+++ b/claude/agents/code-refactor-advisor.md
@@ -2,7 +2,7 @@
 name: code-refactor-advisor
 description: A read-only agent that builds a responsibility map of the whole codebase and surfaces refactor candidates based on Go conventions / DDD conventions / test conventions. Triggered by things like 「refactor 候補出して」「責務曖昧さチェック」「層境界レビュー」「Go 的に怪しい箇所探して」. Does not Edit or perform git mutations. Writes out a plan file and hands off to the main agent / dev-cycle / direct implementation.
 tools: Read, Grep, Glob, Bash, Skill, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, WebFetch
-model: claude-fable-5
+model: fable
 ---
 
 > **Source of truth:** `claude/ja/agents/code-refactor-advisor.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.

--- a/claude/agents/dev-cycle.md
+++ b/claude/agents/dev-cycle.md
@@ -72,7 +72,7 @@ For other languages / frameworks, handle the implementation stage with your own 
 - Derive in-house using the same method as loop-mode (including impact analysis and the DoD self-check), write the plan to the state file, then **get approval via ExitPlanMode** before moving on (subsequent interactive-mode approval points unchanged)
 
 **Common**:
-- The state file is `<ticket-slug>.md` in the per-project plans dir (its structure takes the "state file template" at the end of this file as the SoT)
+- The state file is `<ticket-slug>.md` in the per-project plans dir. **The SoT for its structure is `~/.claude/skills/dev-loop/references/dev-cycle-state-file.md`** — Read it before writing out the plan and build the file exactly as the template says
 
 **Boundary report**:
 ```
@@ -110,25 +110,9 @@ If the plan includes a new service / new RPC / new enum / new ACL model / new AD
 
 **Before starting implementation, isolate with `EnterWorktree`** (common to loop-mode and interactive mode). After isolation, write to the state file using the absolute path fixed during startup preparation (the auto-resolved path changes when cwd changes). Pin down the base's ahead / behind numbers with the git procedure in verify-before-assert (don't infer them from how `git status`'s "Recent commits" looks).
 
-**If launched with a cwd inside a worktree** (e.g., a parallel-cycle collision): EnterWorktree cannot create a nested worktree from inside one. Identify the main checkout and create your own worktree off main (or origin/main) with `git worktree add`, then move into it. Never touch files inside another agent's worktree.
-
 **If base is not the default branch** (e.g., stacking on top of a parent branch in a stacked PR): `EnterWorktree`'s create path is unusable because its default baseRef is `origin/<default-branch>`. Create a worktree with an explicit base via `git worktree add -b <branch> <path> <parent branch>`, and enter it with `EnterWorktree(path: <path>)`. Record the base branch in the state file and pass it explicitly when delegating to commit-push-branch (needed for both the squash base ref and `gh pr create --base`).
 
-If Edit/Write to the newly created worktree keeps being rejected (under subagent cwd pinning, `EnterWorktree(path)` may report success while the write boundary does not actually move — 2026-07-15 FB), switch to a branch swap inside the pinned original worktree:
-
-1. Clean up the new worktree with `git worktree remove`
-2. **Ownership check**: mechanically confirm via reverse lookup that the original worktree is not owned by another active cycle — grep the state files in the per-project plans dir; if an active state file (= one whose Current state does not show all stages completed / terminated by escalation) records this worktree path under `worktree:`, treat it as owned (recent mtime as a secondary signal)
-3. If it is owned, do not swap; escalate and stop (the "never touch another agent's worktree" principle)
-4. Once confirmed safe, run `git fetch origin <base-ref>` to refresh the remote-tracking ref
-5. Continue by swapping only the branch inside the original worktree directory via `git checkout -b <branch> origin/<base-ref>` (the original branch's commits are preserved)
-
-**When cwd is pinned to the main checkout** (under a background job's bgIsolation guard): the branch swap above is not usable — swapping would hijack the user's checkout. The guard also rejects the Write/Edit tools for **every path under the repo root**, so a worktree created under `.claude/worktrees/` is not writable either. In this case create the worktree **outside the repo root**:
-
-1. **Probe what the guard actually blocks**: try a Write to `/tmp` and a write from a Bash subprocess. If both succeed, the guard is a path-scoped Write/Edit tool block rooted at the repo checkout, not a session-wide block
-2. `git worktree add <path as a sibling of the repo> origin/<base-ref>` to create the worktree outside the repo root (if one was already created inside, relocate it with `git worktree move`)
-3. From then on, Write/Edit via absolute paths. The shared checkout is never touched, so the guard's intent is honored
-
-**If Write/Edit is still rejected**, generate files with a Bash heredoc (`cat > <path> <<'EOF'`) or python, and run git / go etc. via `cd <worktree> && ...`. Do not change settings to disable the guard.
+**If worktree isolation fails or is rejected** (launched with a cwd inside a worktree / subagent cwd pinning / the bgIsolation guard / Write rejected): Read `~/.claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md` for the recovery branches and follow it (don't read it on the normal path). The common principles = never touch another agent's worktree / never hijack the user's checkout / never disable the guard.
 
 **Tie-break when the spec contradicts itself**: when a spec demands "behavior unchanged (regression-guarded)" and separately prescribes a new internal behavior on the same shared code path, **the regression-guarded invariant wins**. Implement the new behavior only where it does not alter the guarded path, and flag the divergence as an SD (the spec itself should also be corrected by merge time).
 
@@ -139,7 +123,7 @@ Read the plan and determine the type of implementation:
 | Go module initial setup (no go.mod or missing skeleton) | `Skill: go-bootstrap` | (within dev-cycle) |
 | Go DDD+TDD feature work (additions to existing internal/) | `Agent: go-feature-tdd` | opus (pinned in frontmatter) |
 | Docs changes (design docs / README / runbooks etc.) with real volume | delegate to an `Agent: general-purpose` subagent | **opus** (specified at spawn) |
-| Non-Go code / config changes with real volume | delegate to an `Agent: general-purpose` subagent | **opus** (specified at spawn — sonnet coding proved insufficient in field verification, 2026-07-15 FB; difficulty-based routing to be revisited once insights accumulate) |
+| Non-Go code / config changes with real volume | delegate to an `Agent: general-purpose` subagent | **opus** (specified at spawn — pinned to opus because sonnet coding proved insufficient in field verification; difficulty-based routing to be revisited once insights accumulate) |
 | Changes that finish in a handful of tool calls (small docs fixes / config changes in 1-2 files / few-line edits) | your own `Read` / `Edit` / `Write` | (within dev-cycle; delegate only work with real volume that is genuinely independent — CLAUDE.md "出力と委任の作法") |
 
 When delegating, pass the work item's spec, the relevant plan steps, the verification commands, and the **conventions digest + source paths (startup preparation Step 5)** fully in the prompt (assume the subagent doesn't know the state file — make it self-contained). Always include these 2 points in an implementation-delegation prompt: "comments are WHY only (don't write the WHAT)" and "consolidate magic numbers / repeated literals into named consts" (SoT: go-style §8 / the code-quality perspective).
@@ -221,7 +205,7 @@ Before spawning, run one verification pass from `~/.claude/rules/verify-before-a
 - Launch `commit-push-branch` via the `Skill` tool
 - **loop-mode**: no approval wait — decide the branch name / commit message automatically → commit → push → **create a draft PR** (the loop-mode extension of `commit-push-branch`; its SKILL.md is the SoT for details). The draft PR body includes the implementation plan, DoD check results, and self-review / security review results (template defined on the commit-push-branch side)
 - **Interactive mode**: as before, confirm the skill's proposed branch name / commit message once via AskUserQuestion right before the commit. After push, obtain the PR creation URL but do not auto-create a draft PR (per CLAUDE.md "push / PR etiquette", PR creation happens separately after user instruction)
-- Commit messages **default to a single-line title, content only**. No why / background / impact scope
+- commit-push-branch is the SoT for the commit message convention (single-line title, content only)
 
 **Boundary report**:
 ```
@@ -310,87 +294,10 @@ Results:
 - Hijacking the main checkout's branch to work during a resume
 - Reporting an outward operation as "done" without a receipt
 
-## Appendix: skill / subagent dependencies
+## Appendix: invocation structure
 
-```
-dev-cycle (this)
-  ├── api-design-review (skill)                          ← design review (upstream; new contract / ADR / ACL model)
-  ├── go-bootstrap (skill)                               ← implementation (initial setup)
-  ├── go-feature-tdd (subagent)                          ← implementation (feature work)
-  ├── review-orchestrator (subagent, opus)               ← review integrating principal (loop-mode, fresh spawn per iteration)
-  │     ├── review-lens (subagent, sonnet)               ← per-perspective review worker (N in parallel, synchronous launch; only when the scale gate says fan-out)
-  │     └── independent-reviewer (subagent, opus)        ← independent review (judges from spec + diff only)
-  ├── self-review-changes (skill)                        ← review (interactive mode) / SoT of the perspective system (references/)
-  ├── security-review-local (skill)                      ← security review
-  ├── commit-push-branch (skill)                         ← commit & push (+ draft PR in loop-mode)
-  └── retrospect (skill)                                 ← end-of-cycle insight recording
-```
-
-Each tool can be invoked independently. If the user says "redo just the self-review" or similar, call that skill directly.
+The subordinate tools are exactly as in the "Subordinate tools" table. Nesting occurs only in the review stage: `review-orchestrator` (opus) synchronously spawns `review-lens` (sonnet, N in parallel only when the scale gate says fan-out) and `independent-reviewer` (opus) beneath itself. Each tool can be invoked independently — if the user says "redo just the self-review" or similar, call that skill directly.
 
 ## state file template
 
-The structure of the state file (`<ticket-slug>.md` in the per-project plans dir). It is the write target of implementation-plan derivation and the SoT for context bootstrap by subsequent agents / on resume:
-
-```
-# <Phase> / <Ticket ID>: <title> — implementation plan
-
-## Context
-Why this change is needed (DoD-based)
-
-## Confirmed decisions
-Enumerate the confirmed literals. Reference source on reimplementation; used by subsequent agents for context bootstrap. Put permanent design decisions here.
-| Decision item | Adopted literal | Basis (DoD / docs) |
-
-## Scope decisions (intentional limits derived from the DoD)
-Scope limits the DoD explicitly states as "stub only is OK" / "implement in a follow-up ticket". Not deviations, so don't flag them in the PR description.
-| Scope-limit item | DoD basis | Follow-up ticket |
-
-## Spec deviations (flagged in the PR description, reviewer-check targets)
-Only "permanent structural choices" where the implementation diverges from DoD / docs. Keep only the items you want the reviewer to check.
-| # | Deviation | Remediation policy (spec update / keep / revisit later) |
-
-## Phase 2+ migration (turned into follow-up tickets)
-Provisional implementations slated for future refactor. Recorded as follow-ups, not implemented in this PR.
-| Provisional implementation | Target form | Follow-up ticket / link |
-
-## Carryover (existing issues, separate ticket)
-Existing issues outside scope that this PR won't touch but are worth keeping in view.
-| Existing issue | Impact scope | Handling ticket |
-
-## Documentation updates (Tier classification)
-Tier-based organization of the contradictions extracted from the docs cross-check, and how they're handled in this ticket.
-| Target doc | Fix content | Tier (1/2/3/4) | Handling (same commit / same PR / separate ticket) |
-
-## Impact scope
-The impact-A/B/C classification and the "target symbol → referencing site" mapping table (output of the impact analysis in implementation-plan derivation)
-
-## Current state (updated as you go)
-Progress state. So a subsequent agent / resume can context-bootstrap with a single Read.
-At the planning stage, write only "not yet performed" — don't write pre-measurement values, commit shas, PR URLs, or review round counts (preventing fabrication under the pressure to fill in the template).
-- Stage X done / Y in progress (corresponding to wip commits)
-- Latest commit: <hash> / test-fix attempt count: <n>/3
-- Pending questions / escalation stop (<stage> / <reason>)
-
-## Design review (api-design-review)
-Result summary (detection status across the 6 perspectives / reflected / user-judged / remaining follow-up)
-
-## Key design decisions
-| Decision item | Decision | Basis |
-
-## Implementation steps (in execution order)
-### Step 1: ...
-- New / edited files + content overview
-
-## DoD-to-implementation-step mapping
-| DoD item | Corresponding Step | Verification method |
-
-## Anticipated pitfalls
-
-## Verification steps (after implementation)
-
-## Handoff to the next ticket (out of scope)
-
-## References
-- ticket URL / docs paths / original path of the repo conventions digest
-```
+The SoT for its structure is `~/.claude/skills/dev-loop/references/dev-cycle-state-file.md` (see "Common" under implementation-plan derivation). Not restated in this file.

--- a/claude/agents/review-orchestrator.md
+++ b/claude/agents/review-orchestrator.md
@@ -37,7 +37,7 @@ The review-side principal of dev-cycle's review iteration loop. A **fresh spawn 
 4. **Perform the perspective review**: Read `self-review-changes` SKILL.md + references/ to enumerate the perspectives and their mechanical skip conditions, then follow the gate's result
    - **4a. fan-out**: launch a `review-lens` subagent (sonnet) in parallel per performed perspective, and launch an `independent-reviewer` subagent (opus) alongside
    - **4b. inline**: don't launch `review-lens`; apply the perspective references yourself, sequentially. Launch only `independent-reviewer` synchronously (a second judgment that doesn't depend on implementation context is kept regardless of scale)
-   - **Launches must always be synchronous (`run_in_background: false`)** — background launches make results unrecoverable on interruption (2026-07-15 FB)
+   - **Launches must always be synchronous (`run_in_background: false`)** — background launches make results unrecoverable on interruption
    - Mark impact-C areas as priority targets in the prompts for the correctness / test-adversarial perspectives
    - **Don't instruct review-lens to pre-filter by severity**: have it return every finding, and triage in the integration at step 5 (a filtering instruction reduces the reporting itself)
    - **State the read-only boundary explicitly in the prompt** (including when spawning `general-purpose` etc. for fact-checking purposes): include as boilerplate "read-only. Do not modify anything outside the target repo / worktree (in particular session artifacts under `~/.claude/`). If you judge that a change is needed, do not do it — report and stop"

--- a/claude/ja/agents/code-refactor-advisor.md
+++ b/claude/ja/agents/code-refactor-advisor.md
@@ -2,7 +2,7 @@
 name: code-refactor-advisor
 description: コード全体の責務マップを作り、Go お作法 / DDD お作法 / test お作法ベースで refactor 候補を出す read-only agent。「refactor 候補出して」「責務曖昧さチェック」「層境界レビュー」「Go 的に怪しい箇所探して」等で起動する。Edit / git mutation はしない。plan ファイルを書き出し、main agent / dev-cycle / 直接実装に引き継ぐ。
 tools: Read, Grep, Glob, Bash, Skill, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, WebFetch
-model: claude-fable-5
+model: fable
 ---
 
 # code-refactor-advisor

--- a/claude/ja/agents/dev-cycle.md
+++ b/claude/ja/agents/dev-cycle.md
@@ -70,7 +70,7 @@ tools: Skill, Agent, Read, Write, Edit, Bash, Grep, Glob, TaskCreate, TaskUpdate
 - loop-mode と同じ手法で内製導出し (影響範囲調査・DoD self-check 含む)、plan を state file に書いた上で **ExitPlanMode で承認を取ってから**次工程へ進む (以降の対話 mode 承認 point は従来通り)
 
 **共通**:
-- state file は per-project plans dir の `<ticket-slug>.md` (構成は本ファイル末尾の「state file template」を SoT とする)
+- state file は per-project plans dir の `<ticket-slug>.md`。**構成の SoT は `~/.claude/skills/dev-loop/references/dev-cycle-state-file.md`** — 計画の書き出し前に Read して template どおりに作る
 
 **境界の報告**:
 ```
@@ -108,25 +108,9 @@ tools: Skill, Agent, Read, Write, Edit, Bash, Grep, Glob, TaskCreate, TaskUpdate
 
 **実装に入る前に `EnterWorktree` で分離する** (loop-mode・対話mode共通)。分離後は state file への書き込みに Step起動時の準備で確定した絶対パスを使う (cwd変化で自動解決パスが変わるため)。base の ahead / behind 判定は verify-before-assert の git 手順で数値確定する (`git status` の "Recent commits" の見た目から推測しない)。
 
-**worktree 内の cwd で起動された場合** (並列 cycle の衝突等): EnterWorktree は worktree 内からのネスト作成ができない。main checkout を特定し、`git worktree add` で自前の worktree を main (or origin/main) から作成して移動する。他 agent の worktree 内のファイルには触れない。
-
 **base が default branch でない場合** (stacked PR で親 branch の上に積む等): `EnterWorktree` の新規作成は既定 baseRef が `origin/<default-branch>` のため使えない。`git worktree add -b <branch> <path> <親 branch>` で base 指定の worktree を作り、`EnterWorktree(path: <path>)` で入る。base branch は state file に記録し、commit-push-branch への委譲時に明示的に渡す (squash の base ref と `gh pr create --base` の両方で必要)。
 
-作成した新規 worktree への Edit/Write が拒否され続ける場合 (subagent の cwd pin 下では `EnterWorktree(path)` が成功を報告しても書き込み境界が移らない — 2026-07-15 FB) は、pin 済みの元 worktree 内でのブランチ差し替えに切り替える:
-
-1. 新規 worktree を `git worktree remove` で片付ける
-2. **所有確認**: 元 worktree が他の稼働中 cycle の所有でないことを逆引きで機械的に確認する — per-project plans dir の state file 群を grep し、当該 worktree path を `worktree:` に記録する active な state file (= Current state が全工程完了 / escalation 終了を示していないもの) があれば所有中と判定 (直近 mtime は補助)
-3. 所有中なら差し替えず escalation して停止する (「他 agent の worktree に触れない」原則)
-4. 安全を確認したら `git fetch origin <base-ref>` で remote-tracking ref を更新する
-5. 元 worktree ディレクトリ内で `git checkout -b <branch> origin/<base-ref>` によりブランチだけ差し替えて続行する (元ブランチの commit は保持される)
-
-**cwd が main checkout に pin されている場合** (background job の bgIsolation guard 下): 上記のブランチ差し替えは使えない — 差し替えると user の checkout を乗っ取る。かつ guard は **repo root 配下の全 path** で Write/Edit tool を拒否するため、`.claude/worktrees/` 配下に作った worktree にも書けない。この場合は **repo root の外**に worktree を作る:
-
-1. **guard の性質を probe で判定**: `/tmp` への Write と Bash subprocess からの書き込みを試す。両方成功するなら、guard は「repo checkout root に path-scoped な Write/Edit tool の遮断」であり session 全体の遮断ではない
-2. `git worktree add <repo と兄弟の path> origin/<base-ref>` で repo root 外に worktree を作成する (既に repo 内に作ってしまった場合は `git worktree move` で外へ退避)
-3. 以降は絶対パスで Write/Edit する。共有 checkout を一切触らないため guard の意図は守られる
-
-**Write/Edit がなお拒否される場合**は Bash heredoc (`cat > <path> <<'EOF'`) か python でファイルを生成し、git / go 等は `cd <worktree> && ...` で実行する。guard を無効化する設定変更は行わない。
+**worktree 分離が失敗・拒否される場合** (worktree 内 cwd での起動 / subagent cwd pin / bgIsolation guard / Write 拒否): 復旧分岐は `~/.claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md` を Read して従う (通常 path では読まない)。共通原則 = 他 agent の worktree に触れない / user の checkout を乗っ取らない / guard を無効化しない。
 
 **spec が自己矛盾している場合の tie-break**: 「挙動不変 (regression-guarded)」の要求と、同じ shared code path に対する新しい内部挙動の指定が spec 内に併存する場合、**regression-guarded な不変条件を優先する**。新しい挙動は guarded path を変えない範囲でのみ実装し、差分を SD として flag する (spec 側の訂正も merge までに行う)。
 
@@ -137,7 +121,7 @@ plan を読み、実装内容のタイプを判定:
 | Go module 初回セットアップ (go.mod なし or 骨格不足) | `Skill: go-bootstrap` | (dev-cycle 内) |
 | Go の DDD+TDD 機能追加 (既存 internal/ に追加) | `Agent: go-feature-tdd` | opus (frontmatter 固定) |
 | docs 変更 (設計 doc / README / runbook 等) で分量のあるもの | `Agent: general-purpose` subagent に委譲 | **opus** (spawn 時に指定) |
-| Go 以外の code / 設定ファイル変更 で分量のあるもの | `Agent: general-purpose` subagent に委譲 | **opus** (spawn 時に指定 — sonnet coding は実地検証で品質不足と判明、2026-07-15 FB。難易度別 routing は insights 蓄積後に再検討) |
+| Go 以外の code / 設定ファイル変更 で分量のあるもの | `Agent: general-purpose` subagent に委譲 | **opus** (spawn 時に指定 — sonnet coding は実地検証で品質不足のため opus 固定。難易度別 routing は insights 蓄積後に再検討) |
 | 数回の tool 呼び出しで終わる変更 (小規模 docs 修正 / 1-2 file の設定変更 / 数行の edit) | 自前で `Read` / `Edit` / `Write` | (dev-cycle 内。委任は分量があり真に独立な作業に限る — CLAUDE.md「出力と委任の作法」) |
 
 委譲時は work item の spec・実装計画の該当 step・検証コマンド・**規約 digest + 原本 path (起動時の準備 Step 5)** を prompt で完全に渡す (subagent は state file を知らない前提で自己完結させる)。実装委譲 prompt には「comment は WHY のみ (WHAT を書かない)」「magic number / 繰り返す literal は named const に集約」の 2 点を常に含める (SoT: go-style §8 / code-quality 観点)。
@@ -219,7 +203,7 @@ spawn の前に、本 cycle で自分が書いた doc / ADR / comment 散文へ 
 - `Skill` tool で `commit-push-branch` を起動
 - **loop-mode**: 承認待ちせず branch名/commitメッセージを自動決定 → commit → push → **draft PR 作成** (`commit-push-branch` の loop-mode拡張。詳細はそちらのSKILL.mdをSoTとする)。draft PR bodyには実装計画・DoDチェック結果・self-review/security review結果を含める (テンプレートはcommit-push-branch側で定義)
 - **対話 mode**: 従来通り、skillが提案したbranch名/commitメッセージをcommit直前にAskUserQuestionで1回確認。push完了後、PR作成URLを取得するが draft PR自動作成はしない (CLAUDE.md「push/PRの作法」通り、PR作成は別途user指示後)
-- commit messageは **default で title 1 行・変更内容のみ**。why / 背景 / 影響範囲は付けない
+- commit message の規約 (title 1 行・変更内容のみ) は commit-push-branch が SoT
 
 **境界の報告**:
 ```
@@ -308,87 +292,10 @@ loop-mode で escalation 条件 (鉄則 2/3) に当たったら、以下を順�
 - resume で main checkout の branch を乗っ取って作業する
 - 外向き操作を receipt なしで「実施済み」と報告する
 
-## 補足: skill / subagent の依存関係
+## 補足: 呼び出し構造
 
-```
-dev-cycle (this)
-  ├── api-design-review (skill)                  ← 設計 review (上流、新contract/新ADR/新ACLモデル時)
-  ├── go-bootstrap (skill)                        ← 実装 (初回セットアップ)
-  ├── go-feature-tdd (subagent)                   ← 実装 (機能追加)
-  ├── review-orchestrator (subagent, opus)         ← review 統合主体 (loop-mode、反復ごとにfresh spawn)
-  │     ├── review-lens (subagent, sonnet)          ← 観点別 review worker (N並列、同期起動。規模 gate が fan-out の時のみ)
-  │     └── independent-reviewer (subagent, opus)   ← 独立 review (spec + diffのみで判断)
-  ├── self-review-changes (skill)                 ← review (対話 mode) / 観点体系のSoT (references/)
-  ├── security-review-local (skill)                ← security review
-  ├── commit-push-branch (skill)                   ← commit & push (+ loop-modeはdraft PR)
-  └── retrospect (skill)                            ← サイクル末のinsight記録
-```
-
-各道具は独立して呼び出し可能。ユーザーが「self-reviewだけやり直したい」等と言ったら直接skillを呼んで対応する。
+配下の道具は「配下の道具」の表どおり。nesting は review 工程のみ: review-orchestrator (opus) が配下に review-lens (sonnet、規模 gate が fan-out の時のみ N 並列) と independent-reviewer (opus) を同期 spawn する。各道具は独立して呼び出し可能 — ユーザーが「self-review だけやり直したい」等と言ったら直接 skill を呼んで対応する。
 
 ## state file template
 
-state file (per-project plans dir の `<ticket-slug>.md`) の構成。実装計画導出の書き出し先で、後続 agent / 再開時の context bootstrap の SoT:
-
-```
-# <Phase> / <Ticket ID>: <タイトル> — 実装プラン
-
-## Context
-なぜこの変更が必要か (DoD ベース)
-
-## Confirmed decisions
-確定した literal を列挙。再実装時の参照源、後続 agent が context bootstrap に使う。永続的な設計判断はここに置く。
-| 判断項目 | 採用 literal | 根拠 (DoD / docs どちら) |
-
-## Scope decisions (DoD 由来の意図的限定)
-DoD で「stub のみで OK」「後続 ticket で実装」と明示されている範囲限定。逸脱ではないので PR description には flag しない。
-| 範囲限定項目 | DoD 根拠 | 後続 ticket |
-
-## Spec deviations (PR description で flag、reviewer 確認対象)
-DoD / docs と実装で割れる「永続的な構造選択」のみ。reviewer に確認したい項目だけを残す。
-| # | 逸脱内容 | 是正方針 (spec update / 維持 / 後日見直し) |
-
-## Phase 2+ migration (follow-up ticket 化)
-暫定実装で将来 refactor 予定のもの。follow-up として記録、本 PR では実装しない。
-| 暫定実装 | 将来形 | follow-up ticket / link |
-
-## Carryover (既存問題、別 ticket)
-scope 外の既存問題で、本 PR では触らないが視認しておきたいもの。
-| 既存問題 | 影響範囲 | 対応 ticket |
-
-## Documentation updates (Tier 分類)
-docs 突合で抽出した矛盾箇所の Tier 別整理と本 ticket での扱い。
-| 対象 doc | 修正内容 | Tier (1/2/3/4) | 扱い (同 commit / 同 PR / 別 ticket) |
-
-## 影響範囲
-impact-A/B/C の分類と「対象 symbol → 参照元」の対応表 (実装計画導出の影響範囲調査の出力)
-
-## Current state (随時更新)
-進行状態。後続 agent / 再開時に Read 1 回で context bootstrap できるように。
-計画段階では「未実施」とだけ書く — 実測前の値・commit sha・PR URL・review 周回数を書かない (template を埋める圧力による捏造防止)。
-- Stage X 完了 / Y 進行中 (wip commit と対応)
-- 直近 commit: <hash> / test 修正試行カウント: <n>/3
-- Pending questions / escalation 停止 (<工程> / <理由>)
-
-## Design review (api-design-review)
-実行結果 summary (6 観点の検出有無 / 反映済み / user 判断済み / 残置 follow-up)
-
-## 主要な設計判断
-| 判断項目 | 決定 | 根拠 |
-
-## 実装ステップ (実行順)
-### Step 1: ...
-- 新規 / 編集ファイル + 内容概要
-
-## DoD と実装ステップの対応
-| DoD 項目 | 対応 Step | 検証方法 |
-
-## 想定される落とし穴
-
-## 検証手順 (実装完了後)
-
-## 次のチケットへの引き継ぎ (スコープ外)
-
-## 参照
-- ticket URL / docs のパス / repo 規約 digest の原本 path
-```
+構成の SoT は `~/.claude/skills/dev-loop/references/dev-cycle-state-file.md` (実装計画導出の「共通」参照)。本ファイルには再掲しない。

--- a/claude/ja/agents/review-orchestrator.md
+++ b/claude/ja/agents/review-orchestrator.md
@@ -35,7 +35,7 @@ dev-cycle の review 反復 loop の review 側主体。**実装 context を持�
 4. **観点 review の実施**: `self-review-changes` SKILL.md + references/ を Read して観点と機械的 skip 条件を列挙し、gate の結果に従う
    - **4a. fan-out**: 実施観点ごとに `review-lens` subagent (sonnet) を並列起動、並走で `independent-reviewer` subagent (opus) を起動する
    - **4b. inline**: `review-lens` を起動せず、観点 references を自ら逐次適用する。`independent-reviewer` のみ同期起動する (実装 context に依らない第二判断は規模に関わらず維持)
-   - **起動は必ず同期 (`run_in_background: false`)** — background 起動は中断時に結果が回収不能になる (2026-07-15 FB)
+   - **起動は必ず同期 (`run_in_background: false`)** — background 起動は中断時に結果が回収不能になる
    - impact-C 領域は correctness / test-adversarial への prompt で重点対象として明記する
    - **review-lens に severity の事前絞りを指示しない**: findings は全件返させ、取捨は手順 5 の統合で行う (絞り指示は報告そのものを減らす)
    - **read-only 委譲の境界を prompt に明記する** (fact-check 目的で `general-purpose` 等を spawn する場合を含む): 「read-only。対象 repo / worktree の外 (とくに `~/.claude/` 配下の session artifact) を変更しない。変更が必要と判断したら実行せず報告して停止する」を定型句として入れる

--- a/claude/ja/skills/api-design-review/SKILL.md
+++ b/claude/ja/skills/api-design-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: api-design-review
 description: API / 上流設計 (ADR / Design Doc / API 契約 / ドメインモデル / ACL) の考慮漏れを 6 軸で洗い出す read-only review skill。wire 表現に落とす前の logical 設計段階 — ExitPlanMode 前 / ADR 起票時 / Design Doc draft 完成時 — に invoke する。「設計 review して」「考慮漏れチェック」等で使う。
-model: claude-fable-5
+model: fable
 ---
 
 # api-design-review

--- a/claude/ja/skills/arc42-c4/SKILL.md
+++ b/claude/ja/skills/arc42-c4/SKILL.md
@@ -1,54 +1,54 @@
 ---
 name: arc42-c4
-description: Reference for architecture design docs combining arc42 (§1-12) with the C4 model (L1-L4) — which diagram goes in which section, top-level vs subsystem split. Use for "which section gets what", "§5 vs §6 vs §7", "ADR inside or separate". Reference skill, not a procedure.
+description: arc42 (§1-12) と C4 model (L1-L4) を組み合わせた architecture 設計ドキュメントの reference。どの diagram をどの section に置くか、top-level と subsystem の分割を扱う。「どの section に何を書くか」「§5 vs §6 vs §7」「ADR は本文内か別出しか」等の問いで使う。手順 skill ではない。
 ---
 
 # arc42-c4
 
-arc42 (sections) and C4 (diagrams) are independent conventions; neither spec says which C4 diagram belongs in which arc42 section. **This skill pins that mapping as a house standard** to kill per-doc ambiguity. Project-specific doc maps live in the project's top-level design doc, not here.
+arc42 (section 体系) と C4 (diagram 体系) は独立した規約であり、どちらの spec も「どの C4 diagram をどの arc42 section に置くか」を定めていない。**本 skill がその mapping を house standard として固定する** — doc ごとの揺れを排除するため。project 固有の doc map は project の top-level 設計ドキュメント側に置き、本 skill には書かない。
 
-Use when writing / reviewing an arc42 + C4 design doc, or deciding the ADR / runbook / README boundary. Supplies section judgment to `tech-docs-writer`; a review lens to `api-design-review`.
+arc42 + C4 の設計ドキュメントを書く / review する場面、および ADR / runbook / README の境界を決める場面で参照する。`tech-docs-writer` には section 判断を、`api-design-review` には review 観点を供給する。
 
 ## arc42 §1-12
 
 1 Introduction & Goals · 2 Constraints · 3 Context & Scope · 4 Solution Strategy · 5 Building Block View · 6 Runtime View · 7 Deployment View · 8 Crosscutting Concepts · 9 Architecture Decisions · 10 Quality Requirements · 11 Risks & Tech Debt · 12 Glossary
 
-- **§5 vs §6 vs §7** (same blocks, different axis): §5 = static structure ("is X a part?") · §6 = behavior over time ("what order do parts talk for use case Y?", insight-bearing scenarios only) · §7 = physical placement ("which node runs X?").
-- **§2 vs §4 vs §10** (same fact can appear in all three): §2 = limits you couldn't choose · §4 = fundamental choices you made · §10 = measurable quality scenarios. PostgreSQL: "policy mandates it" → §2; "we chose it for integrity" → §4; "reads < 50ms p95" → §10. §10 holds ends not means; §9 holds decision index not full ADRs.
+- **§5 vs §6 vs §7** (対象は同じ block、軸が違う): §5 = 静的構造 (「X は構成要素か」) · §6 = 時間軸の振る舞い (「use case Y で構成要素がどの順に対話するか」、洞察のある scenario のみ) · §7 = 物理配置 (「X はどの node で動くか」)。
+- **§2 vs §4 vs §10** (同じ事実が 3 つ全てに現れ得る): §2 = 選べなかった制約 · §4 = 自ら下した根本的な選択 · §10 = 計測可能な品質 scenario。PostgreSQL の例: 「方針で必須」→ §2 / 「整合性のために選んだ」→ §4 / 「read が p95 50ms 未満」→ §10。§10 は手段ではなく目的を置く。§9 は ADR 全文ではなく decision の index を置く。
 
-## arc42 × C4 mapping (house standard — decisive)
+## arc42 × C4 mapping (house standard — 決定事項)
 
 | C4 | arc42 |
 |----|-------|
 | L1 System Context | **§3** |
 | L2 Container | **§5** (top level) |
-| L3 Component | **§5** (lower level / subsystem doc) |
-| L4 Code | §5 deepest, or omit |
+| L3 Component | **§5** (下位 level / subsystem doc) |
+| L4 Code | §5 の最深部、または省略 |
 | dynamic diagram | **§6** |
 | deployment diagram | **§7** |
 
-The 4 numbered C4 levels are **all static**; runtime → §6, placement → §7. **Dedup:** container structure in §5, container-on-infra mapping in §7 — cross-reference, never paste twice.
+番号付きの C4 4 levels は**全て静的**。runtime は §6、配置は §7 へ。**重複排除**: container の構造は §5、container と infra の対応は §7 — 相互参照で繋ぎ、同じものを 2 度貼らない。
 
-## Multi-doc split (top-level ⇄ subsystem)
+## 複数 doc への分割 (top-level ⇄ subsystem)
 
-Fold line = container boundary. **Top-level doc** owns L1 + L2 (the subsystem map / hand-off seam). **Subsystem doc** (one per container) owns L3 (+ L4 if used). The Container diagram is the join: top lists all containers, each subsystem points at its own then expands to components. Subsystem docs may use a **mini** arc42 subset (full §1-12 only at top level).
+折り目 = container 境界。**top-level doc** が L1 + L2 を持つ (subsystem の地図 / 引き継ぎの継ぎ目)。**subsystem doc** (container 1 つに 1 本) が L3 (+ 使うなら L4) を持つ。Container diagram が接合点: top-level が全 container を列挙し、各 subsystem doc は自分の container を指してから component へ展開する。subsystem doc は arc42 の **mini** subset でよい (§1-12 全部は top-level のみ)。
 
-## Boundary with adjacent conventions
+## 隣接規約との境界
 
-arc42 = durable design-time "shape + rationale". Different audience / cadence → separate doc, arc42 only **links**.
+arc42 = 設計時点の「構造 + 根拠」を長期保持するもの。読者層 / 更新頻度が違うものは別 doc に切り、arc42 からは **link のみ**張る。
 
-| Convention | Location | arc42 touchpoint |
+| 規約 | 配置 | arc42 側の接点 |
 |-----------|----------|------------------|
-| MADR (ADR) | `docs/adr/NNNN-*.md` | **§9 = index only** (id/title/status/link); full rationale, alternatives, consequences in the file |
-| Diataxis (README/guides) | `docs/readme/` | link from §8 |
-| SRE Playbook (runbook) | `docs/runbook/` | link from §7 / §11 |
+| MADR (ADR) | `docs/adr/NNNN-*.md` | **§9 は index のみ** (id / title / status / link)。根拠・代替案・帰結の全文は file 側 |
+| Diataxis (README / guides) | `docs/readme/` | §8 から link |
+| SRE Playbook (runbook) | `docs/runbook/` | §7 / §11 から link |
 
-Cut an ADR when a decision is costly to reverse, contested, or constrains the future.
+ADR を切る基準は、覆すのに costly な決定・意見が割れた決定・将来を縛る決定。
 
-## Common mistakes
+## よくある間違い
 
-Flow in §5, or §7 re-pasting §5's diagram · treating a C4 level as "runtime" (all 4 are static) · freely-chosen tech filed under §2 · means in §10 instead of measurable ends · full ADR body in §9 · L1/L2 duplicated in subsystem docs · re-litigating the C4↔arc42 mapping as "just convention" (it's pinned above).
+§5 に flow を書く / §7 に §5 の diagram を貼り直す · C4 の level を「runtime」扱いする (4 つとも静的) · 自由に選べた技術を §2 に入れる · §10 に計測可能な目的ではなく手段を書く · §9 に ADR 本文を書く · subsystem doc に L1 / L2 を重複させる · C4↔arc42 の mapping を「単なる慣習」として再議論する (上で固定済み)。
 
-## Related skills
+## 関連 skill
 
-`tech-docs-writer` (writes the doc) · `api-design-review` (reviews it) · `ddd-clean-architecture` (§5 / §8 layer boundaries).
+`tech-docs-writer` (doc を書く) · `api-design-review` (doc を review する) · `ddd-clean-architecture` (§5 / §8 の layer 境界)。

--- a/claude/ja/skills/dev-loop/SKILL.md
+++ b/claude/ja/skills/dev-loop/SKILL.md
@@ -5,7 +5,7 @@ description: /loop で回す dev loop の driver skill。1 tick = work-intake po
 
 # dev-loop
 
-Dev loop の driver。**loop の生死は user の /loop 操作が管理し、本 skill は 1 tick の中身を規定する**。1 tick = 1 poll + 最大 1 cycle。
+Dev loop の driver。1 tick = 1 poll + 最大 1 cycle。**時刻取得・通知 3 区分・wakeup 基準値・3 連続 breaker・tick 報告の共通規定は `references/loop-driver-common.md` が SoT** — 本文で再掲しない。
 
 ## 適用条件
 
@@ -16,7 +16,6 @@ Dev loop の driver。**loop の生死は user の /loop 操作が管理し、�
 
 ### Step 1: 前提確認
 
-- `date '+%Y-%m-%d %H:%M %Z'` を実行して現在時刻 (現地) を取得する — tick 報告の時刻欄用。時刻を推測で書かない
 - git repo 内であること
 - **直列 guard**: per-project plans dir の state file 群を確認し、active な cycle (Current state が全工程完了 / escalation 停止を示していない state file) が存在しないこと。存在するなら本 tick は cycle を起動せず Step 5 へ (300s wakeup — 実行中 cycle の完了待ち)
 - Notion 到達性は work-intake に委ねる (不達なら Step 2 が異常終了 → 「Notion 不達」を通知して 1800s wakeup)
@@ -44,19 +43,11 @@ dev-cycle の報告から receipts を取り、**実在を機械確認してか�
 | escalation | ticket コメント / WIP branch (`git ls-remote`) を確認 | 「<ticket-id>: escalation (<停止理由 1 行>)」 |
 | receipts が実在しない | — | 「<ticket-id>: 報告と実態の乖離を検出」+ escalation 扱いでカウント |
 
-- 通知結果は **3 区分**で扱い、tick 報告に必ず記す: **送信** (発行された) / **skip (terminal active)** = user が terminal で active なため tool が意図的に抑止 — **正常** (通知は無人時のみ配達される仕様) / **未達** (tool 不可・エラー — 異常。沈黙しない)
-
 ### Step 5: self-pacing (`ScheduleWakeup`)
 
-| 直前の結果 | 次 wakeup | 理由 |
-|---|---|---|
-| cycle 完走 | 60-120s | drain — 続きの ready をすぐ消化 |
-| 空 queue (該当なし) | 1200-1800s | idle (20-30 分) |
-| escalation | 1200-1800s | 通常継続 (対象 ticket は InProgress で再 pick されない) |
-| 直列 guard hit | 300s | 実行中 cycle の完了待ち |
-| Notion 不達 | 1800s | 復旧待ち |
-
-- **連続 escalation breaker**: escalation (乖離検出を含む) が **3 連続**したら wakeup を止め (`ScheduleWakeup` stop)、「loop 停止 (escalation 3 連続)」を通知して終了する。連続カウントは cycle 完走でリセット
+- 基準値は loop-driver-common (完走 → drain / 空 queue → idle / 直列 guard hit → 300s)
+- 固有: escalation → 1200-1800s (対象 ticket は InProgress で再 pick されない) / Notion 不達 → 1800s (復旧待ち)
+- breaker の対象 = escalation (乖離検出を含む)。リセットは cycle 完走
 
 ### Step 6: tick の報告 (強制出力)
 
@@ -73,7 +64,5 @@ dev-cycle の報告から receipts を取り、**実在を機械確認してか�
 ## 鉄則
 
 1. **並列 cycle を起動しない** — 直列 guard を skip しない
-2. **通知は receipts の実在検証後** — dev-cycle の自己申告をそのまま転送しない
-3. **escalation で loop を止めない** — 例外は 3 連続 breaker のみ
-4. **loop の恒久停止は user の /loop 操作** — breaker 発動時も「停止した」通知を必ず送る
-5. **tick 報告を省略しない** — 全項目を毎 tick 出力する
+2. **escalation で loop を止めない** — 例外は 3 連続 breaker のみ
+3. **共通規定 (receipts 検証 / breaker / tick 報告 / 停止権限) は loop-driver-common に従う**

--- a/claude/ja/skills/dev-loop/references/dev-cycle-state-file.md
+++ b/claude/ja/skills/dev-loop/references/dev-cycle-state-file.md
@@ -1,0 +1,66 @@
+# dev-cycle state file template
+
+state file (per-project plans dir の `<ticket-slug>.md`) の構成の SoT。dev-cycle が実装計画導出で書き出し、後続 agent / 再開時の context bootstrap に使う。
+
+```
+# <Phase> / <Ticket ID>: <タイトル> — 実装プラン
+
+## Context
+なぜこの変更が必要か (DoD ベース)
+
+## Confirmed decisions
+確定した literal を列挙。再実装時の参照源、後続 agent が context bootstrap に使う。永続的な設計判断はここに置く。
+| 判断項目 | 採用 literal | 根拠 (DoD / docs どちら) |
+
+## Scope decisions (DoD 由来の意図的限定)
+DoD で「stub のみで OK」「後続 ticket で実装」と明示されている範囲限定。逸脱ではないので PR description には flag しない。
+| 範囲限定項目 | DoD 根拠 | 後続 ticket |
+
+## Spec deviations (PR description で flag、reviewer 確認対象)
+DoD / docs と実装で割れる「永続的な構造選択」のみ。reviewer に確認したい項目だけを残す。
+| # | 逸脱内容 | 是正方針 (spec update / 維持 / 後日見直し) |
+
+## Phase 2+ migration (follow-up ticket 化)
+暫定実装で将来 refactor 予定のもの。follow-up として記録、本 PR では実装しない。
+| 暫定実装 | 将来形 | follow-up ticket / link |
+
+## Carryover (既存問題、別 ticket)
+scope 外の既存問題で、本 PR では触らないが視認しておきたいもの。
+| 既存問題 | 影響範囲 | 対応 ticket |
+
+## Documentation updates (Tier 分類)
+docs 突合で抽出した矛盾箇所の Tier 別整理と本 ticket での扱い。
+| 対象 doc | 修正内容 | Tier (1/2/3/4) | 扱い (同 commit / 同 PR / 別 ticket) |
+
+## 影響範囲
+impact-A/B/C の分類と「対象 symbol → 参照元」の対応表 (実装計画導出の影響範囲調査の出力)
+
+## Current state (随時更新)
+進行状態。後続 agent / 再開時に Read 1 回で context bootstrap できるように。
+計画段階では「未実施」とだけ書く — 実測前の値・commit sha・PR URL・review 周回数を書かない (template を埋める圧力による捏造防止)。
+- Stage X 完了 / Y 進行中 (wip commit と対応)
+- 直近 commit: <hash> / test 修正試行カウント: <n>/3
+- Pending questions / escalation 停止 (<工程> / <理由>)
+
+## Design review (api-design-review)
+実行結果 summary (6 観点の検出有無 / 反映済み / user 判断済み / 残置 follow-up)
+
+## 主要な設計判断
+| 判断項目 | 決定 | 根拠 |
+
+## 実装ステップ (実行順)
+### Step 1: ...
+- 新規 / 編集ファイル + 内容概要
+
+## DoD と実装ステップの対応
+| DoD 項目 | 対応 Step | 検証方法 |
+
+## 想定される落とし穴
+
+## 検証手順 (実装完了後)
+
+## 次のチケットへの引き継ぎ (スコープ外)
+
+## 参照
+- ticket URL / docs のパス / repo 規約 digest の原本 path
+```

--- a/claude/ja/skills/dev-loop/references/dev-cycle-worktree-recovery.md
+++ b/claude/ja/skills/dev-loop/references/dev-cycle-worktree-recovery.md
@@ -1,0 +1,29 @@
+# dev-cycle worktree 復旧手順 (contingency)
+
+通常 path (EnterWorktree が成功する場合) では読む必要のない分岐集。dev-cycle の実装工程で worktree 分離が失敗・拒否された時にだけ参照する。
+
+## worktree 内の cwd で起動された場合 (並列 cycle の衝突等)
+
+EnterWorktree は worktree 内からのネスト作成ができない。main checkout を特定し、`git worktree add` で自前の worktree を main (or origin/main) から作成して移動する。他 agent の worktree 内のファイルには触れない。
+
+## 新規 worktree への Edit/Write が拒否され続ける場合
+
+subagent の cwd pin 下では `EnterWorktree(path)` が成功を報告しても書き込み境界が移らない。pin 済みの元 worktree 内でのブランチ差し替えに切り替える:
+
+1. 新規 worktree を `git worktree remove` で片付ける
+2. **所有確認**: 元 worktree が他の稼働中 cycle の所有でないことを逆引きで機械的に確認する — per-project plans dir の state file 群を grep し、当該 worktree path を `worktree:` に記録する active な state file (= Current state が全工程完了 / escalation 終了を示していないもの) があれば所有中と判定 (直近 mtime は補助)
+3. 所有中なら差し替えず escalation して停止する (「他 agent の worktree に触れない」原則)
+4. 安全を確認したら `git fetch origin <base-ref>` で remote-tracking ref を更新する
+5. 元 worktree ディレクトリ内で `git checkout -b <branch> origin/<base-ref>` によりブランチだけ差し替えて続行する (元ブランチの commit は保持される)
+
+## cwd が main checkout に pin されている場合 (background job の bgIsolation guard 下)
+
+上記のブランチ差し替えは使えない — 差し替えると user の checkout を乗っ取る。かつ guard は **repo root 配下の全 path** で Write/Edit tool を拒否するため、`.claude/worktrees/` 配下に作った worktree にも書けない。この場合は **repo root の外**に worktree を作る:
+
+1. **guard の性質を probe で判定**: `/tmp` への Write と Bash subprocess からの書き込みを試す。両方成功するなら、guard は「repo checkout root に path-scoped な Write/Edit tool の遮断」であり session 全体の遮断ではない
+2. `git worktree add <repo と兄弟の path> origin/<base-ref>` で repo root 外に worktree を作成する (既に repo 内に作ってしまった場合は `git worktree move` で外へ退避)
+3. 以降は絶対パスで Write/Edit する。共有 checkout を一切触らないため guard の意図は守られる
+
+## Write/Edit がなお拒否される場合
+
+Bash heredoc (`cat > <path> <<'EOF'`) か python でファイルを生成し、git / go 等は `cd <worktree> && ...` で実行する。guard を無効化する設定変更は行わない。

--- a/claude/ja/skills/dev-loop/references/loop-driver-common.md
+++ b/claude/ja/skills/dev-loop/references/loop-driver-common.md
@@ -1,0 +1,36 @@
+# loop driver 共通規定 (dev-loop / review-loop / pr-follow-loop)
+
+/loop で回す driver skill 3 種の共通規定。各 skill はここを参照し、本文で再掲しない。**loop の生死は user の /loop 操作が管理し、skill は 1 tick の中身だけを規定する。**
+
+## 時刻
+
+- tick 冒頭で `date '+%Y-%m-%d %H:%M %Z'` を実行して現地時刻を取得する (tick 報告用)。時刻を推測で書かない
+
+## 通知の 3 区分 (tick 報告に必ず記す)
+
+| 区分 | 意味 | 扱い |
+|---|---|---|
+| 送信 | PushNotification が発行された | 正常 |
+| skip (terminal active) | user が terminal で active なため tool が意図的に抑止 | **正常** (通知は無人時のみ配達される仕様) |
+| 未達 | tool 不可・エラー | **異常** — 沈黙せず報告する |
+
+通知・完了報告は **receipts (PR URL / comment URL / 消滅確認等) の実在を機械確認してから**行う。subagent の自己申告をそのまま転送しない。
+
+## self-pacing の基準値 (`ScheduleWakeup`)
+
+| 状況 | 次 wakeup |
+|---|---|
+| 1 歩進んだ (drain — 続きを即消化) | 60-120s |
+| 対象なし (idle) | 1200-1800s |
+| エラー後の再試行 | 900s |
+| 実行中の外部処理の完了待ち | 300s |
+
+skill 固有の行 (Notion 不達等) は各 skill 側にのみ書く。
+
+## 3 連続 breaker
+
+失敗 (escalation / error) が **3 連続**したら `ScheduleWakeup` を stop し、「loop 停止 (3 連続)」を**通知してから**終了する (無言で止めない)。成功でカウントをリセット。恒久停止の判断は user の /loop 操作のみ。
+
+## tick 報告
+
+毎 tick、報告 template の**全項目を省略せず出力する**。共通 field: 時刻 (+ 前回 tick 時刻) / poll 結果 / action + receipts / 通知区分 / 連続カウント n/3 / 次 wakeup 秒 (~HH:MM、理由)。

--- a/claude/ja/skills/grill-me/SKILL.md
+++ b/claude/ja/skills/grill-me/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: grill-me
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+description: plan / 設計について shared understanding に到達するまで user を徹底的に interview し、decision tree の各分岐を解消する skill。plan を stress-test したい場面、設計を厳しく問い詰めてほしい場面、「grill me」と言われた場面で使う。
 ---
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+この plan のあらゆる側面について、shared understanding に到達するまで user を徹底的に interview する。design tree の各分岐を辿り、決定間の依存関係を 1 つずつ解消する。各質問には推奨回答を添える。
 
-Ask the questions one at a time.
+質問は 1 問ずつ出す。
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+codebase を調べれば答えが出る質問は、質問せず codebase を調べる。

--- a/claude/ja/skills/improve-harness/SKILL.md
+++ b/claude/ja/skills/improve-harness/SKILL.md
@@ -54,6 +54,7 @@ frontmatter の `target` で振り分ける:
 
 ### Step 5: 改善実装
 
+- **作業は worktree で行う** (`git worktree add -b <branch> <path> <base>`)。main checkout の branch を切り替えない — 稼働 harness (`~/.claude/*` → main checkout working tree の symlink) が別 session で使用中のため、checkout 切替は稼働中の全 session の挙動を変える。merge 後は main checkout で `git pull` して master に追従する
 - ja SoT (`claude/ja/...`) を編集 → en mirror (`claude/...`) は opus subagent へ翻訳委譲する (docs = opus 規約)。mirror を持たないファイル (`rules/` / `CLAUDE.md`) は単一編集
 - proposal が undecided / user 判断を要する (複数案併記・status 体系への介入・外部 account・権限拡大 等) → 実装せず `status: deferred` (reason 付き) で「要判断一覧」へ
 

--- a/claude/ja/skills/pr-follow-loop/SKILL.md
+++ b/claude/ja/skills/pr-follow-loop/SKILL.md
@@ -7,7 +7,7 @@ description: /loop で回す「自分が author の open PR を見届ける」dr
 
 # pr-follow-loop
 
-PR 見届けの driver（dev-loop / review-loop の兄弟）。**loop の lifecycle は user の /loop 操作が管理し、本 skill は 1 tick の内部を定義する。** 1 tick = 1 poll + 1 PR を最大 1 歩。
+PR 見届けの driver（dev-loop / review-loop の兄弟）。1 tick = 1 poll + 1 PR を最大 1 歩。**時刻取得・通知 3 区分・wakeup 基準値・3 連続 breaker・tick 報告の共通規定は `~/.claude/skills/dev-loop/references/loop-driver-common.md` が SoT** — 本文で再掲しない。
 
 三兄弟の棲み分け:
 - **dev-loop** = 自分が PR を「作る」（work-intake → dev-cycle → draft PR）
@@ -24,7 +24,6 @@ PR 見届けの driver（dev-loop / review-loop の兄弟）。**loop の lifecy
 
 ### Step 1: precondition check
 
-- `date '+%Y-%m-%d %H:%M %Z'` で現地時刻を取得（tick report 用、時刻は推測しない）
 - git repo 内 / `gh auth status` が通ること
 
 ### Step 2: poll（機械的）
@@ -67,14 +66,9 @@ poll で拾った PR から 1 件選び（oldest created 優先）、現在の�
 
 ### Step 4: self-pacing（`ScheduleWakeup`）
 
-| 直前の結果 | 次 wakeup | 理由 |
-|---|---|---|
-| 1 歩進んだ（triage 提示 / 掃除完了） | 60-120s | drain — 次の PR / 次段階を即消化 |
-| approve 待ちに移行 | 1200-1800s | Monitor が主 signal、これは fallback heartbeat |
-| 該当なし（0 件 or 全 skip） | 1200-1800s | idle（20-30 分） |
-| error | 900s | retry 間隔 |
-
-- **連続エラー breaker**: tick が **3 連続**で error したら wakeup を停止（`ScheduleWakeup` stop）、「loop 停止（3 連続 error）」を通知して終了。成功でリセット
+- 基準値は loop-driver-common（1 歩進んだ → drain / 該当なし → idle / error → 900s）
+- 固有: approve 待ちに移行 → 1200-1800s（Monitor が主 signal、wakeup は fallback heartbeat）
+- breaker の対象 = tick の error。リセットは成功
 
 ### Step 5: tick report（強制出力）
 
@@ -93,7 +87,6 @@ poll で拾った PR から 1 件選び（oldest created 優先）、現在の�
 1. **approve / request-changes / merge は人間のみ** — loop は GitHub の review state を操作しない
 2. **bot 指摘は triage の提示まで** — 修正適用・decline 返信は user 承認後に対話で実施。loop が独断で fix / decline しない
 3. **掃除は clean 確認必須** — dirty worktree は掃除せず escalation。掃除対象は自 worktree + merge 済 local branch のみ（remote / 他 worktree は不変）。deny された掃除 command は迂回せず人間に提示する
-4. **通知は receipts の実在確認後** — triage 通知・掃除後の消滅・Monitor 起動を機械確認してから報告
-5. **設定を hardcode しない** — bot 名 / 必須 reviewer / repo は reference memory から取得
-6. **tick report を省略しない** — 全項目を毎 tick 出力
-7. **安全装置を緩めない** — hooks / permission deny / least privilege は loop でも一切緩めない
+4. **設定を hardcode しない** — bot 名 / 必須 reviewer / repo は reference memory から取得
+5. **安全装置を緩めない** — hooks / permission deny / least privilege は loop でも一切緩めない
+6. **共通規定（receipts 検証 / breaker / tick 報告 / 停止権限）は loop-driver-common に従う**

--- a/claude/ja/skills/review-loop/SKILL.md
+++ b/claude/ja/skills/review-loop/SKILL.md
@@ -5,7 +5,7 @@ description: /loop で回す PR review の driver skill。1 tick = reviewer assi
 
 # review-loop
 
-PR review の driver (dev-loop の兄弟)。**loop の生死は user の /loop 操作が管理し、本 skill は 1 tick の中身を規定する**。1 tick = 1 poll + 最大 1 review。
+PR review の driver (dev-loop の兄弟)。1 tick = 1 poll + 最大 1 review。**時刻取得・通知 3 区分・wakeup 基準値・3 連続 breaker・tick 報告の共通規定は `~/.claude/skills/dev-loop/references/loop-driver-common.md` が SoT** — 本文で再掲しない。
 
 ## 適用条件
 
@@ -16,7 +16,6 @@ PR review の driver (dev-loop の兄弟)。**loop の生死は user の /loop �
 
 ### Step 1: 前提確認
 
-- `date '+%Y-%m-%d %H:%M %Z'` を実行して現在時刻 (現地) を取得する — tick 報告用。時刻を推測で書かない
 - git repo 内であること / `gh auth status` が通ること
 
 ### Step 2: poll (機械実行)
@@ -57,15 +56,8 @@ verdict: <approve / approve-with-notes / fix-required / escalation>
 
 ### Step 6: 通知 + self-pacing
 
-- **全 review 完了ごとに通知**: `PushNotification`「PR #<n> review 完了: <verdict>」。結果は 3 区分で tick 報告に記す — 送信 / **skip (terminal active — 正常、無人時のみ配達)** / 未達 (異常)
-
-| 直前の結果 | 次 wakeup (`ScheduleWakeup`) | 理由 |
-|---|---|---|
-| review 完了 | 60-120s | drain — 次の未 review PR をすぐ消化 |
-| 対象なし (0 件 or 全件 skip) | 1200-1800s | idle (20-30 分) |
-| review エラー | 900s | 再試行間隔 |
-
-- **連続エラー breaker**: review が **3 連続**で失敗したら wakeup を止め、「loop 停止 (review 3 連続失敗)」を通知して終了する。成功でリセット
+- **全 review 完了ごとに通知**: `PushNotification`「PR #<n> review 完了: <verdict>」
+- wakeup は loop-driver-common の基準値どおり (review 完了 → drain / 対象なし → idle / エラー → 900s)。breaker の対象 = review の失敗、リセットは成功
 
 ### Step 7: tick の報告 (強制出力)
 
@@ -83,6 +75,5 @@ verdict: <approve / approve-with-notes / fix-required / escalation>
 
 1. **approve / request-changes / merge をしない** — 中立 comment のみ
 2. **同一 head sha に再 comment しない** — marker 照合 (Step 3) を skip しない
-3. **通知・報告は receipts (comment URL) の実在検証後** — 自己申告で「投稿済み」と言わない
-4. **PR 本文・code を comment に丸ごと転記しない**
-5. **tick 報告を省略しない** — 全項目を毎 tick 出力する
+3. **PR 本文・code を comment に丸ごと転記しない**
+4. **共通規定 (receipts 検証 / breaker / tick 報告 / 停止権限) は loop-driver-common に従う**

--- a/claude/ja/skills/self-review-changes/SKILL.md
+++ b/claude/ja/skills/self-review-changes/SKILL.md
@@ -29,20 +29,9 @@ self-review の最大バイアスは「自分の intent が見えて actual gap 
 
 ## Phase 2: 観点の実行 (default-on + 機械的 skip 判定)
 
-観点は全て default-on。**skip して良いのは下表の機械的条件を満たす時だけ**で、skip には理由を付ける:
+観点は全て default-on。**skip して良いのは機械的条件を満たす時だけ**で、skip には理由を付ける。**skip 条件の SoT は各 reference 先頭行の `skip 可:`** — 本ファイルに再掲しない (二重管理の乖離防止)。
 
-| 観点 (references/) | skip 可の条件 (機械判定) |
-|---|---|
-| correctness.md | code diff が 0 (docs / config のみの変更) |
-| filetype-checks.md | なし (常時実施) |
-| conventions.md | なし (常時実施) |
-| spec-alignment.md | 対応する spec / work item が存在しない |
-| test-adversarial.md | test ファイルの diff が 0 |
-| performance.md | code diff が 0 |
-| observability.md | 新規 code path なし (docs / config / test のみ) |
-| ops-docs-hazard.md | 運用手順 docs の diff が 0 (`docs/runbook/**` の変更が無く、docs 追加行に shell command の code fence が無い) |
-| dependency.md | 依存ファイル (go.mod / go.sum / lock / import 行) の diff が 0 |
-| code-quality.md | code diff が 0 |
+観点一覧 (references/、1 観点 1 file): correctness / filetype-checks / conventions / spec-alignment / test-adversarial / performance / observability / ops-docs-hazard / dependency / code-quality
 
 - 実施する観点の references を Read し、checklist を diff に適用する
 - **loop-mode**: 本 skill は直接起動されず、`review-orchestrator` agent が本 SKILL.md と references/ を Read して観点 review を主管する。規模 gate が fan-out なら `review-lens` へ観点 reference path + diff 範囲 + spec を渡し並列・**同期**起動、inline なら reviewer 自身が観点 references を逐次適用する (gate の SoT は review-orchestrator 手順 3-4)。対話時は inline で順に実施

--- a/claude/ja/skills/self-review-changes/references/correctness.md
+++ b/claude/ja/skills/self-review-changes/references/correctness.md
@@ -55,4 +55,4 @@ project context 上「適用不可」と判断して resolve するパターン:
 
 差分に外部由来の hardcoded 定数 (LLM pricing / model ID / API rate limit / 第三者サービスの定数) が含まれる場合、port 元・memory・既存コードとの一致確認で済ませず、**authoritative source で数値そのものを検証**する。Anthropic の pricing / model ID の SoT は claude-api skill (「LLM pricing は memory で答えない」trigger をコードレビュー文脈でも適用)。
 
-例: ccwatch から port した Opus レート $15/$75 は port 元と byte 一致だったが、現行レートは $5/$25 で 3x 過大計上 (2026-07-17 FB。「port 元と一致」は正当性の根拠にならない)。
+例: port 元と byte 一致の Opus レートが現行レートの 3 倍で過大計上 —「port 元と一致」は正当性の根拠にならない。

--- a/claude/skills/api-design-review/SKILL.md
+++ b/claude/skills/api-design-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: api-design-review
 description: A read-only review skill that surfaces overlooked considerations in API / upstream design (ADR / Design Doc / API contracts / domain models / ACL) across 6 axes. Invoke it at the logical design stage, before it's committed to a wire representation — before ExitPlanMode / when drafting an ADR / when a Design Doc draft is complete. Used for things like 「設計 review して」「考慮漏れチェック」.
-model: claude-fable-5
+model: fable
 ---
 
 > **Source of truth:** `claude/ja/skills/api-design-review/SKILL.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.

--- a/claude/skills/dev-loop/SKILL.md
+++ b/claude/skills/dev-loop/SKILL.md
@@ -7,7 +7,7 @@ description: Driver skill for the dev loop run via /loop. 1 tick = work-intake p
 
 # dev-loop
 
-The dev loop's driver. **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most 1 cycle.
+The dev loop's driver. 1 tick = 1 poll + at most 1 cycle. **`references/loop-driver-common.md` is the SoT for the common provisions — getting the time, the 3 notification categories, the wakeup baseline values, the 3-consecutive breaker, and the tick report** — not restated in this body.
 
 ## Applicability conditions
 
@@ -18,7 +18,6 @@ The dev loop's driver. **The loop's lifecycle is managed by the user's /loop ope
 
 ### Step 1: Precondition check
 
-- Run `date '+%Y-%m-%d %H:%M %Z'` to get the current local time — for the tick report's time line; never guess the time
 - Must be inside a git repo
 - **Serial guard**: check the state files in the per-project plans dir, and ensure no active cycle exists (a state file whose Current state does not indicate all-stages-complete / escalation stop). If one exists, this tick does not start a cycle and goes to Step 5 (300s wakeup — waiting for the running cycle to finish)
 - Leave Notion reachability to work-intake (if unreachable, Step 2 terminates abnormally → notify "Notion unreachable" and 1800s wakeup)
@@ -46,19 +45,11 @@ Take the receipts from dev-cycle's report, and **notify via `PushNotification` o
 | escalation | Confirm the ticket comment / WIP branch (`git ls-remote`) | 「<ticket-id>: escalation (<one-line stop reason>)」 |
 | receipts do not actually exist | — | 「<ticket-id>: detected a divergence between report and reality」 + counted as escalation |
 
-- Notification outcomes are handled in **3 categories** and always recorded in the tick report: **sent** (issued) / **skipped (terminal active)** = the tool deliberately suppressed it because the user is active at the terminal — **normal** (notifications are only delivered when unattended, by design) / **not delivered** (tool unavailable / error — abnormal; never stay silent)
-
 ### Step 5: self-pacing (`ScheduleWakeup`)
 
-| Immediately preceding result | Next wakeup | Reason |
-|---|---|---|
-| cycle completed | 60-120s | drain — consume the next ready right away |
-| empty queue (none applicable) | 1200-1800s | idle (20-30 min) |
-| escalation | 1200-1800s | normal continuation (the target ticket is InProgress and won't be re-picked) |
-| serial guard hit | 300s | waiting for the running cycle to finish |
-| Notion unreachable | 1800s | waiting for recovery |
-
-- **Consecutive escalation breaker**: if escalation (including divergence detection) occurs **3 consecutive** times, stop the wakeup (`ScheduleWakeup` stop), notify "loop stopped (3 consecutive escalations)", and terminate. The consecutive count resets on a cycle completion
+- The baseline values come from loop-driver-common (completed → drain / empty queue → idle / serial guard hit → 300s)
+- Skill-specific: escalation → 1200-1800s (the target ticket is InProgress and won't be re-picked) / Notion unreachable → 1800s (waiting for recovery)
+- The breaker's target = escalation (including divergence detection). It resets on a cycle completion
 
 ### Step 6: tick report (forced output)
 
@@ -75,7 +66,5 @@ Take the receipts from dev-cycle's report, and **notify via `PushNotification` o
 ## Iron rules
 
 1. **Do not start parallel cycles** — do not skip the serial guard
-2. **Notify only after verifying the receipts actually exist** — do not forward dev-cycle's self-report as-is
-3. **Do not stop the loop on escalation** — the only exception is the 3-consecutive breaker
-4. **Permanent loop stop is the user's /loop operation** — even when the breaker fires, always send the "stopped" notification
-5. **Do not omit the tick report** — output all items every tick
+2. **Do not stop the loop on escalation** — the only exception is the 3-consecutive breaker
+3. **Follow loop-driver-common for the common provisions** (receipts verification / breaker / tick report / stop authority)

--- a/claude/skills/dev-loop/references/dev-cycle-state-file.md
+++ b/claude/skills/dev-loop/references/dev-cycle-state-file.md
@@ -1,0 +1,68 @@
+> **Source of truth:** `claude/ja/skills/dev-loop/references/dev-cycle-state-file.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# dev-cycle state file template
+
+The SoT for the structure of the state file (`<ticket-slug>.md` in the per-project plans dir). dev-cycle writes it out during implementation-plan derivation, and subsequent agents / resumes use it for context bootstrap.
+
+```
+# <Phase> / <Ticket ID>: <title> — implementation plan
+
+## Context
+Why this change is needed (DoD-based)
+
+## Confirmed decisions
+Enumerate the confirmed literals. Reference source on reimplementation; used by subsequent agents for context bootstrap. Put permanent design decisions here.
+| Decision item | Adopted literal | Basis (DoD / docs) |
+
+## Scope decisions (intentional limits derived from the DoD)
+Scope limits the DoD explicitly states as "stub only is OK" / "implement in a follow-up ticket". Not deviations, so don't flag them in the PR description.
+| Scope-limit item | DoD basis | Follow-up ticket |
+
+## Spec deviations (flagged in the PR description, reviewer-check targets)
+Only "permanent structural choices" where the implementation diverges from DoD / docs. Keep only the items you want the reviewer to check.
+| # | Deviation | Remediation policy (spec update / keep / revisit later) |
+
+## Phase 2+ migration (turned into follow-up tickets)
+Provisional implementations slated for future refactor. Recorded as follow-ups, not implemented in this PR.
+| Provisional implementation | Target form | Follow-up ticket / link |
+
+## Carryover (existing issues, separate ticket)
+Existing issues outside scope that this PR won't touch but are worth keeping in view.
+| Existing issue | Impact scope | Handling ticket |
+
+## Documentation updates (Tier classification)
+Tier-based organization of the contradictions extracted from the docs cross-check, and how they're handled in this ticket.
+| Target doc | Fix content | Tier (1/2/3/4) | Handling (same commit / same PR / separate ticket) |
+
+## Impact scope
+The impact-A/B/C classification and the "target symbol → referencing site" mapping table (output of the impact analysis in implementation-plan derivation)
+
+## Current state (updated as you go)
+Progress state. So a subsequent agent / resume can context-bootstrap with a single Read.
+At the planning stage, write only "not yet performed" — don't write pre-measurement values, commit shas, PR URLs, or review round counts (preventing fabrication under the pressure to fill in the template).
+- Stage X done / Y in progress (corresponding to wip commits)
+- Latest commit: <hash> / test-fix attempt count: <n>/3
+- Pending questions / escalation stop (<stage> / <reason>)
+
+## Design review (api-design-review)
+Result summary (detection status across the 6 perspectives / reflected / user-judged / remaining follow-up)
+
+## Key design decisions
+| Decision item | Decision | Basis |
+
+## Implementation steps (in execution order)
+### Step 1: ...
+- New / edited files + content overview
+
+## DoD-to-implementation-step mapping
+| DoD item | Corresponding Step | Verification method |
+
+## Anticipated pitfalls
+
+## Verification steps (after implementation)
+
+## Handoff to the next ticket (out of scope)
+
+## References
+- ticket URL / docs paths / original path of the repo conventions digest
+```

--- a/claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md
+++ b/claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md
@@ -1,0 +1,31 @@
+> **Source of truth:** `claude/ja/skills/dev-loop/references/dev-cycle-worktree-recovery.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# dev-cycle worktree recovery procedures (contingency)
+
+A set of branches you never need to read on the normal path (when EnterWorktree succeeds). Consult it only when worktree isolation fails or is rejected during dev-cycle's implementation stage.
+
+## If launched with a cwd inside a worktree (e.g., a parallel-cycle collision)
+
+EnterWorktree cannot create a nested worktree from inside one. Identify the main checkout and create your own worktree off main (or origin/main) with `git worktree add`, then move into it. Never touch files inside another agent's worktree.
+
+## If Edit/Write to the newly created worktree keeps being rejected
+
+Under subagent cwd pinning, `EnterWorktree(path)` may report success while the write boundary does not actually move. Switch to a branch swap inside the pinned original worktree:
+
+1. Clean up the new worktree with `git worktree remove`
+2. **Ownership check**: mechanically confirm via reverse lookup that the original worktree is not owned by another active cycle — grep the state files in the per-project plans dir; if an active state file (= one whose Current state does not show all stages completed / terminated by escalation) records this worktree path under `worktree:`, treat it as owned (recent mtime as a secondary signal)
+3. If it is owned, do not swap; escalate and stop (the "never touch another agent's worktree" principle)
+4. Once confirmed safe, run `git fetch origin <base-ref>` to refresh the remote-tracking ref
+5. Continue by swapping only the branch inside the original worktree directory via `git checkout -b <branch> origin/<base-ref>` (the original branch's commits are preserved)
+
+## When cwd is pinned to the main checkout (under a background job's bgIsolation guard)
+
+The branch swap above is not usable — swapping would hijack the user's checkout. The guard also rejects the Write/Edit tools for **every path under the repo root**, so a worktree created under `.claude/worktrees/` is not writable either. In this case create the worktree **outside the repo root**:
+
+1. **Probe what the guard actually blocks**: try a Write to `/tmp` and a write from a Bash subprocess. If both succeed, the guard is a path-scoped Write/Edit tool block rooted at the repo checkout, not a session-wide block
+2. `git worktree add <path as a sibling of the repo> origin/<base-ref>` to create the worktree outside the repo root (if one was already created inside, relocate it with `git worktree move`)
+3. From then on, Write/Edit via absolute paths. The shared checkout is never touched, so the guard's intent is honored
+
+## If Write/Edit is still rejected
+
+Generate files with a Bash heredoc (`cat > <path> <<'EOF'`) or python, and run git / go etc. via `cd <worktree> && ...`. Do not change settings to disable the guard.

--- a/claude/skills/dev-loop/references/loop-driver-common.md
+++ b/claude/skills/dev-loop/references/loop-driver-common.md
@@ -1,0 +1,38 @@
+> **Source of truth:** `claude/ja/skills/dev-loop/references/loop-driver-common.md` (Japanese). To update, edit the Japanese source first, then re-translate this file into English.
+
+# Common provisions for loop drivers (dev-loop / review-loop / pr-follow-loop)
+
+Provisions shared by the 3 driver skills run via /loop. Each skill references this file and does not restate it in its own body. **The loop's lifecycle is managed by the user's /loop operation; a skill only defines the internals of one tick.**
+
+## Time
+
+- At the head of the tick, run `date '+%Y-%m-%d %H:%M %Z'` to get the current local time (for the tick report). Never guess the time
+
+## The 3 notification categories (always recorded in the tick report)
+
+| Category | Meaning | Handling |
+|---|---|---|
+| sent | `PushNotification` was issued | normal |
+| skipped (terminal active) | the tool deliberately suppressed it because the user is active at the terminal | **normal** (notifications are only delivered when unattended, by design) |
+| not delivered | tool unavailable / error | **abnormal** — report it; never stay silent |
+
+Notifications and completion reports happen **only after mechanically confirming that the receipts (PR URL / comment URL / removal confirmation, etc.) actually exist**. Do not forward a subagent's self-report as-is.
+
+## Baseline values for self-pacing (`ScheduleWakeup`)
+
+| Situation | Next wakeup |
+|---|---|
+| advanced one step (drain — consume the next right away) | 60-120s |
+| none applicable (idle) | 1200-1800s |
+| retry after an error | 900s |
+| waiting for a running external process to finish | 300s |
+
+Skill-specific rows (Notion unreachable, etc.) are written only on the skill's own side.
+
+## The 3-consecutive breaker
+
+If failures (escalation / error) occur **3 consecutive** times, stop `ScheduleWakeup` and terminate **after notifying** "loop stopped (3 consecutive)" (never stop silently). The count resets on a success. Only the user's /loop operation decides a permanent stop.
+
+## tick report
+
+Every tick, **output all items of the report template without omission**. Common fields: time (+ previous tick's time) / poll result / action + receipts / notification category / consecutive count n/3 / next wakeup seconds (~HH:MM, reason).

--- a/claude/skills/improve-harness/SKILL.md
+++ b/claude/skills/improve-harness/SKILL.md
@@ -56,6 +56,7 @@ Sort by the `target` in the frontmatter:
 
 ### Step 5: Implement the improvement
 
+- **Do the work in a worktree** (`git worktree add -b <branch> <path> <base>`). Don't switch the main checkout's branch — the live harness (`~/.claude/*` → symlinks into the main checkout's working tree) is in use by other sessions, so a checkout switch changes the behavior of every running session. After the merge, run `git pull` in the main checkout to catch up with master
 - Edit the ja SoT (`claude/ja/...`) → delegate the en mirror (`claude/...`) translation to an opus subagent (docs = opus convention). Files with no mirror (`rules/` / `CLAUDE.md`) are edited in a single place
 - If the proposal is undecided / requires user judgment (multiple options listed / intervention in the status scheme / external accounts / privilege escalation, etc.) → do not implement; set `status: deferred` (with reason) and add it to the "decisions-needed list"
 

--- a/claude/skills/pr-follow-loop/SKILL.md
+++ b/claude/skills/pr-follow-loop/SKILL.md
@@ -7,7 +7,7 @@ description: Driver skill run via /loop that shepherds the open PRs I authored. 
 
 # pr-follow-loop
 
-The driver for shepherding PRs (sibling of dev-loop / review-loop). **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most one step on one PR.
+The driver for shepherding PRs (sibling of dev-loop / review-loop). 1 tick = 1 poll + at most one step on one PR. **`~/.claude/skills/dev-loop/references/loop-driver-common.md` is the SoT for the common provisions — getting the time, the 3 notification categories, the wakeup baseline values, the 3-consecutive breaker, and the tick report** — not restated in this body.
 
 The three siblings:
 - **dev-loop** = I **produce** PRs (work-intake → dev-cycle → draft PR)
@@ -24,7 +24,6 @@ The three siblings:
 
 ### Step 1: precondition check
 
-- Run `date '+%Y-%m-%d %H:%M %Z'` for the current local time (for the tick report; never guess the time)
 - Must be inside a git repo / `gh auth status` must pass
 
 ### Step 2: poll (mechanical)
@@ -67,14 +66,9 @@ Select one PR from the poll (oldest created first) and, based on its current sta
 
 ### Step 4: self-pacing (`ScheduleWakeup`)
 
-| Immediately preceding result | Next wakeup | Reason |
-|---|---|---|
-| advanced one step (triage presented / cleanup done) | 60-120s | drain — consume the next PR / next stage right away |
-| moved to awaiting-approval | 1200-1800s | Monitor is the primary signal; this is the fallback heartbeat |
-| none applicable (0 or all skipped) | 1200-1800s | idle (20-30 min) |
-| error | 900s | retry interval |
-
-- **Consecutive-error breaker**: if a tick errors **3 consecutive** times, stop the wakeup (`ScheduleWakeup` stop), notify "loop stopped (3 consecutive errors)", and terminate. Resets on success
+- The baseline values come from loop-driver-common (advanced one step → drain / none applicable → idle / error → 900s)
+- Skill-specific: moved to awaiting-approval → 1200-1800s (Monitor is the primary signal; the wakeup is the fallback heartbeat)
+- The breaker's target = tick errors. It resets on a success
 
 ### Step 5: tick report (forced output)
 
@@ -93,7 +87,6 @@ Select one PR from the poll (oldest created first) and, based on its current sta
 1. **Approve / request-changes / merge are the human's only** — the loop never operates GitHub's review state
 2. **Bot findings go only as far as presenting the triage** — applying fixes / posting decline replies happen after the user approves, in dialogue. The loop never fixes / declines on its own
 3. **Cleanup requires a clean check** — a dirty worktree is not cleaned; escalate instead. Cleanup targets are the own worktree + the merged local branch only (remote / other worktrees are left untouched). A denied cleanup command is presented to the human, not worked around
-4. **Notify only after verifying the receipts exist** — mechanically confirm the triage notification / the removal / the Monitor start before reporting
-5. **Do not hardcode configuration** — bot names / required reviewers / repo come from the reference memory
-6. **Do not omit the tick report** — output all items every tick
-7. **Do not loosen the safety devices** — hooks / permission deny / least privilege are never relaxed in the loop
+4. **Do not hardcode configuration** — bot names / required reviewers / repo come from the reference memory
+5. **Do not loosen the safety devices** — hooks / permission deny / least privilege are never relaxed in the loop
+6. **Follow loop-driver-common for the common provisions** (receipts verification / breaker / tick report / stop authority)

--- a/claude/skills/review-loop/SKILL.md
+++ b/claude/skills/review-loop/SKILL.md
@@ -7,7 +7,7 @@ description: Driver skill for PR review run via /loop. 1 tick = poll open PRs wh
 
 # review-loop
 
-The driver for PR review (dev-loop's sibling). **The loop's lifecycle is managed by the user's /loop operation; this skill defines the internals of one tick.** 1 tick = 1 poll + at most 1 review.
+The driver for PR review (dev-loop's sibling). 1 tick = 1 poll + at most 1 review. **`~/.claude/skills/dev-loop/references/loop-driver-common.md` is the SoT for the common provisions — getting the time, the 3 notification categories, the wakeup baseline values, the 3-consecutive breaker, and the tick report** — not restated in this body.
 
 ## Applicability conditions
 
@@ -18,7 +18,6 @@ The driver for PR review (dev-loop's sibling). **The loop's lifecycle is managed
 
 ### Step 1: Precondition check
 
-- Run `date '+%Y-%m-%d %H:%M %Z'` to get the current local time — for the tick report; never guess the time
 - Must be inside a git repo / `gh auth status` must pass
 
 ### Step 2: poll (mechanical)
@@ -59,15 +58,8 @@ verdict: <approve / approve-with-notes / fix-required / escalation>
 
 ### Step 6: notification + self-pacing
 
-- **Notify on every review completion**: `PushNotification` "PR #<n> review complete: <verdict>". The outcome is recorded in the tick report in 3 categories — sent / **skipped (terminal active — normal, delivered only when unattended)** / not delivered (abnormal)
-
-| Immediately preceding result | Next wakeup (`ScheduleWakeup`) | Reason |
-|---|---|---|
-| review completed | 60-120s | drain — consume the next un-reviewed PR right away |
-| none applicable (0 or all skipped) | 1200-1800s | idle (20-30 min) |
-| review error | 900s | retry interval |
-
-- **Consecutive error breaker**: if a review fails **3 consecutive** times, stop the wakeup, notify "loop stopped (3 consecutive review failures)", and terminate. Resets on a success
+- **Notify on every review completion**: `PushNotification` "PR #<n> review complete: <verdict>"
+- The wakeup follows loop-driver-common's baseline values (review completed → drain / none applicable → idle / error → 900s). The breaker's target = review failures, resetting on a success
 
 ### Step 7: tick report (forced output)
 
@@ -85,6 +77,5 @@ verdict: <approve / approve-with-notes / fix-required / escalation>
 
 1. **Do not approve / request-changes / merge** — neutral comment only
 2. **Do not re-comment on the same head sha** — do not skip the marker check (Step 3)
-3. **Notify / report only after verifying the receipts (comment URL) actually exist** — do not claim "posted" on self-report
-4. **Do not transcribe the PR body / code verbatim into the comment**
-5. **Do not omit the tick report** — output all items every tick
+3. **Do not transcribe the PR body / code verbatim into the comment**
+4. **Follow loop-driver-common for the common provisions** (receipts verification / breaker / tick report / stop authority)

--- a/claude/skills/self-review-changes/SKILL.md
+++ b/claude/skills/self-review-changes/SKILL.md
@@ -31,20 +31,9 @@ The biggest bias in self-review is that "you can see your own intent but not the
 
 ## Phase 2: Perspective execution (default-on + mechanical skip judgment)
 
-All perspectives are default-on. **You may skip only when the mechanical condition in the table below is met**, and skips require a reason:
+All perspectives are default-on. **You may skip only when the mechanical condition is met**, and skips require a reason. **The SoT for the skip conditions is the `Skippable:` line at the head of each reference** — not restated in this file (preventing the divergence of dual management).
 
-| Perspective (references/) | Condition allowing skip (mechanical judgment) |
-|---|---|
-| correctness.md | code diff is 0 (docs / config-only change) |
-| filetype-checks.md | none (always performed) |
-| conventions.md | none (always performed) |
-| spec-alignment.md | no corresponding spec / work item exists |
-| test-adversarial.md | the test file diff is 0 |
-| performance.md | code diff is 0 |
-| observability.md | no new code path (docs / config / test only) |
-| ops-docs-hazard.md | the diff of operational-procedure docs is 0 (no changes under `docs/runbook/**`, and no shell-command code fence in the added docs lines) |
-| dependency.md | the diff of dependency files (go.mod / go.sum / lock / import lines) is 0 |
-| code-quality.md | code diff is 0 |
+The perspectives (references/, one perspective per file): correctness / filetype-checks / conventions / spec-alignment / test-adversarial / performance / observability / ops-docs-hazard / dependency / code-quality
 
 - Read the references for the perspectives you will perform, and apply the checklist to the diff
 - **loop-mode**: this skill is not invoked directly; the `review-orchestrator` agent Reads this SKILL.md and references/ and orchestrates the perspective review. If the scale gate says fan-out, it passes the perspective reference path + diff range + spec to `review-lens`, launched in parallel and **synchronously**; if inline, the reviewer applies the perspective references itself, sequentially (review-orchestrator steps 3-4 are the SoT for the gate). In interactive mode, perform them inline in order

--- a/claude/skills/self-review-changes/references/correctness.md
+++ b/claude/skills/self-review-changes/references/correctness.md
@@ -57,4 +57,4 @@ Example: PR #30 C11/C12 — `carryOverlap`'s "kept strictly under overlap" was c
 
 When the diff contains hardcoded externally-sourced constants (LLM pricing / model IDs / API rate limits / third-party service constants), do not settle for matching the port source / memory / existing code — **verify the values themselves against an authoritative source**. The SoT for Anthropic pricing / model IDs is the claude-api skill (apply the "never answer LLM pricing from memory" trigger in code-review contexts too).
 
-Example: Opus rates $15/$75 ported from ccwatch matched the port source byte-for-byte, but the current rates are $5/$25 — a 3x overcount (2026-07-17 FB; "matches the port source" is not evidence of validity).
+Example: Opus rates that matched the port source byte-for-byte were 3x the current rates, producing an overcount — "matches the port source" is not evidence of validity.


### PR DESCRIPTION
## Summary

- #34 の診断で承認された構造的簡素化の実施 (user 承認済み decision 1〜3)。**stacked PR — base は #34 の branch** (`chore/verify-before-assert-and-stale-cleanup`)、merge 順は #34 → 本 PR
- 目的 = 認知負荷と常駐 context の削減: 定型 block の references 分割 (必要時のみ Read) + 重複規範の SoT 一本化

## Changes

| 変更 | 実測 |
|---|---|
| dev-cycle: state file template (66 行) + worktree 復旧手順 (26 行) を `skills/dev-loop/references/` へ分割、依存 tree・FB 日付註記・再掲行を圧縮 | 394 → 301 行 (-24%)。復旧手順は通常 path で Read 不要 |
| loop trio (dev-loop / review-loop / pr-follow-loop): 時刻・通知 3 区分・wakeup 基準値・breaker・tick 報告規則を `loop-driver-common.md` に集約 | 3 skill 計 266 → 239 行 + 共通 34 行 (規定の 3 重管理を解消) |
| self-review-changes: skip 条件表の二重管理を解消 (references 先頭行 `skip 可:` を SoT 化) — dependency 行の文言乖離 (package.json 欠落) も同時解消 | 93 → 82 行 |
| improve-harness: **harness 改善作業は worktree で行う**規約を追加 (main checkout の branch を切り替えない / merge 後に `git pull`) — decision 1 | 本 PR 自体もこの運用で作成 |
| arc42-c4 / grill-me: ja SoT を日本語化 (従来は英語のまま)、en に SoT 注記 | ja README の SoT 規約に整合 |
| model frontmatter を `fable` alias に統一 (code-refactor-advisor / api-design-review) | full ID の version rot を回避。skill の `model:` は有効な設定と docs で確認済み |

## Impact scope

- impact-A: references 新規 3 本 (ja+en)
- impact-C: dev-cycle / loop trio / self-review-changes の既存行の削除・書き換え — **規定の意味は不変で配置のみ変更** (分割した本文は逐語で references へ移動)

## Verification

- ja SoT 編集 → en mirror へ反映後、`git grep loop-driver-common / dev-cycle-state-file / dev-cycle-worktree-recovery` で参照配線を確認
- agent frontmatter の `fable` alias と skill `model:` field の有効性は公式 docs (sub-agents / skills) で確認
- rules/security.md・performance.md の `paths:` 自動 attach は診断の推奨どおり**維持** (変更なし)

## References

- 親 PR: #34 (insight 適用 + 診断)。diff の読み順: loop-driver-common.md → dev-loop → dev-cycle
- 残 follow-up (未実施、必要なら次 run): 横断重複規範の残り (dependency 規範 14 hit / severity 絞り禁止 4 hit / read-only 委譲定型句 2 hit) の rules/ 一本化
