### PR TITLE
:bulb: apply retrospect insights on claim verification, worktree isolation, and ADR triggers

### DIFF
--- a/claude/agents/dev-cycle.md
+++ b/claude/agents/dev-cycle.md
@@ -67,6 +67,12 @@ Overlooked considerations found are put to the user via `AskUserQuestion` in int
 
 **If base is not the default branch** (e.g. stacking on a parent branch in a stacked PR): `EnterWorktree`'s create path is unusable (its default baseRef is `origin/<default-branch>`). Create a worktree with an explicit base via `git worktree add -b <branch> <path> <parent branch>` and enter it with `EnterWorktree(path: <path>)`. Record the base branch in the state file and pass it explicitly when delegating to commit-push-branch (needed for both the squash base ref and `gh pr create --base`).
 
+**Isolation silently reverts to another worktree across session boundaries**. It has been observed multiple times in environments with concurrent cycles, and it leads directly to cwd-dependent relative paths reading / writing another cycle's files. Therefore:
+
+- **Always write Bash / grep / sed / git with absolute paths** (`git -C <worktree>` / `sed -n ... <absolute path>`). Investigation time has actually been wasted on checking with a relative path and concluding "my change wasn't applied"
+- **Immediately before a destructive git operation (`merge` / `commit` / `push` / `checkout`), print `pwd` and `git branch --show-current` in the same command and compare them against the expected values**. A near-miss creating a merge commit on another agent's branch has actually occurred
+- **If `Edit` is rejected on the grounds of isolation to another worktree, re-enter with `EnterWorktree(path:)`**. Don't route around it with a Bash-based replacement (don't set a precedent for bypassing the guard)
+
 **If worktree isolation fails or is rejected**, Read `~/.claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md` and follow it (don't read it on the normal path). The common principles = never touch another agent's worktree / never hijack the user's checkout / never disable the guard.
 
 **Tie-break when the spec contradicts itself**: when "behavior unchanged (regression-guarded)" and a new internal behavior on the same shared code path are demanded together, **the regression-guarded invariant wins**. Implement the new behavior only where it does not alter the guarded path, and flag the divergence as an SD.

--- a/claude/ja/agents/dev-cycle.md
+++ b/claude/ja/agents/dev-cycle.md
@@ -65,6 +65,12 @@ Go 以外の言語 / framework は実装工程を自前の Edit / Bash で扱う
 
 **base が default branch でない場合** (stacked PR の親 branch 上に積む等): `EnterWorktree` の create 経路は使えない (既定 baseRef が `origin/<default-branch>` のため)。`git worktree add -b <branch> <path> <親 branch>` で明示 base の worktree を作り、`EnterWorktree(path: <path>)` で入る。base branch を state file に記録し、commit-push-branch への委譲時に明示的に渡す (squash base ref と `gh pr create --base` の両方で必要)。
 
+**隔離は session 境界で無言に別 worktree へ戻る**。並行 cycle がある環境では実測で複数回起きており、cwd 依存の相対 path が別 cycle の file を読む / 書く事故に直結する。したがって:
+
+- **Bash / grep / sed / git は常に絶対 path で書く** (`git -C <worktree>` / `sed -n ... <絶対 path>`)。相対 path で確認して「自分の変更が適用されていない」と誤認する調査の空費が実際に起きている
+- **git の破壊的操作 (`merge` / `commit` / `push` / `checkout`) の直前に `pwd` と `git branch --show-current` を同一 command で出力し期待値と照合する**。他 agent の branch に merge commit を作る near-miss が実測で発生している
+- **`Edit` が別 worktree への隔離を理由に拒否されたら `EnterWorktree(path:)` で入り直す**。Bash 経由の置換で迂回しない (guard を回る前例を作らない)
+
 **worktree 隔離が失敗 / 拒否された場合**は `~/.claude/skills/dev-loop/references/dev-cycle-worktree-recovery.md` を Read して従う (正常系では読まない)。共通原則 = 他 agent の worktree に触らない / user の checkout を乗っ取らない / guard を無効化しない。
 
 **spec が自己矛盾する場合の tie-break**: 「挙動不変 (regression 防止)」と、同じ共有経路上の新しい内部挙動が同時に要求された場合、**regression 防止の不変条件を優先する**。新挙動は防護対象の経路を変えない範囲でのみ実装し、乖離を SD として flag する。

--- a/claude/ja/skills/api-design-review/SKILL.md
+++ b/claude/ja/skills/api-design-review/SKILL.md
@@ -65,6 +65,14 @@ git grep -nE "<old-name-pattern>"
 
 root の instruction file 群 (`CLAUDE.md` / `.github/copilot-instructions.md` / `.claude/rules/`) は agent が毎回 load するため、stale な契約が後続実装へ伝播する経路 — 必ず含める。逆に改訂履歴 / changelog 行は immutable なので hit しても触らない。
 
+**ADR を起こす前に、その ADR が要るかを grep で確定させる。** repo の「変更は新 ADR で」型の規約は *既存 ADR の決定内容を変える場合* の規定であり、決定が存在しない領域には発動しない。順序:
+
+1. 撤回 / 変更しようとしている決定が既存 ADR に **literal として存在するか** grep する (例: `terminal` の語が対象 ADR に 0 hits なら、その ADR は terminal 意味論を決めていない)
+2. 存在しなければ supersede は発生しない → その領域の SoT (design doc 等) を更新する側に寄せる
+3. **draft に「既存 ADR を Superseded にしない」と書きたくなった時点が、規約の発動条件を満たしていないサイン** — 中断して 1 に戻る
+
+実測事例: この確認を飛ばして ADR を起票し review を 6 周回した後、ADR-0011 に `terminal` が 0 hits で supersede が発生しないと判明して撤回。ADR 番号 1 つと review 予算を消費した。
+
 **名前 grep は必要だが不十分**。設計対象が producer / worker 等の process flow を記述する場合、関連する Accepted ADR / design doc の **flow / lifecycle 記述** (どの行を誰がいつ作るか / dedup 方式 / 失敗時の観測境界) まで読み合わせ、設計案と矛盾しないか確認する。
 
 **新設する状態が既存 runbook の前提遷移を壊さないか**も同時に見る: 新規に書く状態を列挙 → 各状態からの出口が state machine にあるか → 出口の無い terminal 状態を前提にした運用手順 (「redrive で再処理」型) が docs に無いか grep する。terminal 状態の書き手を新設した瞬間に既存手順と矛盾する構造は、実装前のこの段階でしか安く検出できない。

--- a/claude/ja/skills/commit-push-branch/SKILL.md
+++ b/claude/ja/skills/commit-push-branch/SKILL.md
@@ -120,8 +120,8 @@ dev-cycle から渡される材料 = 実装計画 / DoD チェック結果 / spe
 
 1. `git diff <親 tip> origin/<default>` が**空**であることを確認する (空でなければこの手順は使えない)
 2. `git branch backup/<name> <子 tip>` で復旧点を作る
-3. `NEW=$(git commit-tree <子 tip>^{tree} -p origin/<default> -F <msg file>)`
+3. `NEW=$(git commit-tree -S <子 tip>^{tree} -p origin/<default> -F <msg file>)` — **`-S` を必ず付ける**。`commit-tree` は plumbing なので `commit.gpgsign=true` を無視し、collapse の工程だけで署名が落ちる (元 commit は porcelain の `git commit` 産で署名済みでも)。署名必須 repo (`required_signatures: enabled`) では未署名 commit が `mergeState=BLOCKED` になる
 4. `git checkout -B <branch> $NEW` (`reset --hard` は使わない)
-5. `git diff <子 tip> HEAD` が空 (review 済み head と tree が byte 一致) と `git diff origin/<default> HEAD --stat` が想定差分と一致することを機械的に検証する
+5. `git diff <子 tip> HEAD` が空 (review 済み head と tree が byte 一致) と `git diff origin/<default> HEAD --stat` が想定差分と一致すること、**`git log --format='%G?' -1` が `G` (署名検証 OK) を返すこと**を機械的に検証する。`-S` を忘れて未署名になった場合は `git commit --amend --no-edit` で porcelain 再署名する (tree は変わらない)
 
 push は force が必要なので **user の明示指示を待つ** (`--force-with-lease` + backup ref を提示する)。

--- a/claude/ja/skills/self-review-changes/SKILL.md
+++ b/claude/ja/skills/self-review-changes/SKILL.md
@@ -66,6 +66,7 @@ engine が無い場合のみ、入力検証 (0 / 負値 / nil / empty / traversa
 - **一時情報の混入** — `ticket`, `in a later`, `future ticket`, `see (commit|PR) #`, ticket ID 形式。検査 pattern の literal は project の `MEMORY.md` から取得 (skill 側への hardcode は禁止)
 - **cross-reference の実在確認** — コメント内の section 参照の引用語彙が原文と一致するか
 - **推測 mapping** — 原文に書かれていない対応関係をコメントで補完していないか
+- **doc 内の自己矛盾 (claim-vs-claim)** — diff の追加行が主張する事実を、**同一 doc の他 section / 同一 PR の他 file** に対して grep 照合する。code と一致していても他 section と矛盾すれば誤り。特に diff が既存 section の事実を**再掲**している箇所は、再掲をやめて pointer にする方向で指摘する (再掲がある限り編集ごとに矛盾が再生産される)。検証手順の SoT は `~/.claude/rules/verify-before-assert.md`
 
 ### spec-alignment — skip: 対応する spec / work item が無い
 

--- a/claude/rules/verify-before-assert.md
+++ b/claude/rules/verify-before-assert.md
@@ -11,9 +11,14 @@
 | 定量 (行数 / 件数 / 割合 / N 倍 / いつ誰が作ったか) | 測定コマンド (`git diff --numstat` / `grep -c` / `wc` 等) を実行し、主張に測定コマンドを併記する |
 | git の ahead / behind | `git fetch` 後に `git rev-list --count A..B` を両方向 (または `git merge-base --is-ancestor`) で数値確定する。`git status` の "Recent commits" / `git log` の見た目から推測しない |
 | 参照 (section 番号 / 手順名 / file path) | 参照先の実在を grep で確認する |
+| sweep の完了 (除去した / 残りは N 件 / 0 件になった) | **削除対象の全表記形を含むパターン**で grep し、結果を主張に転記する。`ADR-0012` だけで数えて `docs/adr/0012-....md` 形式を取りこぼす類の狭い pattern を receipt にしない |
+| 同一 doc / 同一 PR 内の他 section が所有する事実 | その事実の **owner section を開いて突き合わせる**。code と一致していても他 section と矛盾すれば誤り。突き合わせ先を書けない主張は書かない |
 
 ## 運用
 
 - **subagent の定量・機構主張も同格**: relay (報告 / insight / escalation 資料への転記) の前に自分で同じ検証を実行する。1 行のコマンドで確かめられる事実を未検証のまま人間の判断材料に載せない
 - **review 提出前の doc 散文 pass**: 自分が書いた散文に対し上表の該当種別の検証を review spawn 前に一巡させる。実装 (build / test / lint) が green でも散文が未検証なら review に出さない
+- **receipt の scope は主張の scope と一致させる**: 検証コマンドが主張より狭い範囲しか見ていないなら receipt にならない。「除去した」には全表記形の grep、定量には報告直前の再測定 (記憶や前 round の値を書かない)、状態には「まだやっていないこと」を先書きしない
+- **自己点検は「自分の文を読み直す」ではなく「突き合わせ先を開く」**: 読み直しは元の誤りと同じ盲点 (他 section を見ていない) を再生産する。各主張について owner の section / code を開く工程として実行する
+- **再掲を作らないことが最も安い予防**: 他 section が所有する事実は再掲せず pointer にする。再掲がある限り 1 箇所の編集ごとに「今見ていない箇所」との矛盾が生まれ、claim-vs-claim 照合の負債が残り続ける
 - 検証は grep / Read / コマンドの実行として行う。「確認した」の自己申告で代替しない

--- a/claude/skills/api-design-review/SKILL.md
+++ b/claude/skills/api-design-review/SKILL.md
@@ -67,6 +67,14 @@ git grep -nE "<old-name-pattern>"
 
 Root instruction files (`CLAUDE.md` / `.github/copilot-instructions.md` / `.claude/rules/`) are loaded by the agent every time and are therefore a path by which a stale contract propagates into later implementation — always include them. Conversely, revision history / changelog lines are immutable; don't touch them even on a hit.
 
+**Before drafting an ADR, settle by grep whether that ADR is needed at all.** A repo rule of the "changes go through a new ADR" form governs *changing what an existing ADR decided*; it doesn't fire on an area where no decision exists. The order:
+
+1. Grep whether the decision you're about to retract / change **exists as a literal** in an existing ADR (e.g. if the word `terminal` has 0 hits in the ADR in question, that ADR doesn't decide terminal semantics)
+2. If it doesn't exist, no supersede arises → shift to updating that area's SoT (the design doc, etc.) instead
+3. **The moment you want to write "this does not mark the existing ADR Superseded" in the draft is the sign that the rule's firing condition isn't met** — stop and go back to 1
+
+Case: skipping this check, an ADR was filed and went through 6 review rounds before it turned out `terminal` had 0 hits in ADR-0011 and no supersede arose, so it was retracted. It burned one ADR number and the review budget.
+
 **Grepping names is necessary but not sufficient.** When the design target describes a process flow (producer / worker, etc.), also read the **flow / lifecycle description** of the related Accepted ADRs and design docs (which row is created by whom and when / the dedup method / the observation boundary on failure) and confirm the design doesn't contradict them.
 
 Also check **whether a newly introduced state breaks the transitions an existing runbook assumes**: enumerate the states you'll newly write → confirm each has an exit in the state machine → grep for operational procedures ("redrive to reprocess") that assume a terminal state with no exit. A structure that contradicts existing procedures the moment you add a writer of a terminal state can only be caught cheaply at this pre-implementation stage.

--- a/claude/skills/commit-push-branch/SKILL.md
+++ b/claude/skills/commit-push-branch/SKILL.md
@@ -122,8 +122,8 @@ Once the parent is squash-merged, none of its commits match by patch-id, so `git
 
 1. Confirm `git diff <parent tip> origin/<default>` is **empty** (if not, this procedure doesn't apply)
 2. Create a recovery point with `git branch backup/<name> <child tip>`
-3. `NEW=$(git commit-tree <child tip>^{tree} -p origin/<default> -F <msg file>)`
+3. `NEW=$(git commit-tree -S <child tip>^{tree} -p origin/<default> -F <msg file>)` — **always pass `-S`**. `commit-tree` is plumbing, so it ignores `commit.gpgsign=true` and the signature is dropped by the collapse step alone (even when the original commits were made by porcelain `git commit` and were signed). In a signature-required repo (`required_signatures: enabled`) an unsigned commit ends up `mergeState=BLOCKED`
 4. `git checkout -B <branch> $NEW` (don't use `reset --hard`)
-5. Mechanically verify that `git diff <child tip> HEAD` is empty (the tree is byte-identical to the reviewed head) and that `git diff origin/<default> HEAD --stat` matches the PR's expected diff
+5. Mechanically verify that `git diff <child tip> HEAD` is empty (the tree is byte-identical to the reviewed head), that `git diff origin/<default> HEAD --stat` matches the PR's expected diff, and that **`git log --format='%G?' -1` returns `G` (signature verified)**. If `-S` was forgotten and the commit came out unsigned, re-sign with porcelain via `git commit --amend --no-edit` (the tree doesn't change)
 
 Pushing requires force, so **wait for the user's explicit instruction** (offer `--force-with-lease` + the backup ref).

--- a/claude/skills/self-review-changes/SKILL.md
+++ b/claude/skills/self-review-changes/SKILL.md
@@ -68,6 +68,7 @@ Only when no engine is available, also cover input validation (0 / negative / ni
 - **Transient information leaking in** — `ticket`, `in a later`, `future ticket`, `see (commit|PR) #`, ticket ID formats. Get the literal patterns from the project's `MEMORY.md` (hardcoding them in the skill is forbidden)
 - **Cross-reference existence** — does the quoted wording of a section reference match the original
 - **Speculative mapping** — comments filling in correspondences not written in the original
+- **Self-contradiction within a doc (claim-vs-claim)** — grep the facts the diff's added lines assert against **other sections of the same doc / other files in the same PR**. Agreeing with the code is not enough: contradicting another section makes it wrong. Where the diff **restates** a fact an existing section already states, flag it toward replacing the restatement with a pointer (as long as the restatement exists, every edit regenerates the contradiction). The SoT for the verification procedure is `~/.claude/rules/verify-before-assert.md`
 
 ### spec-alignment — skip: no corresponding spec / work item
 


### PR DESCRIPTION
## Summary

retrospect insight 7 本（すべて 2026-07-31 付）の適用。1 つの dev cycle で review 4 周・critical 21 件が出て、**その全部が agent 自作 doc 散文の事実誤りで code defect は 0 件**だった。既存の `verify-before-assert` は claim-vs-code と claim-vs-measurement しか扱っておらず、**claim-vs-other-claim（同一 doc の他 section が所有する事実との矛盾）が構造的に欠けていた**のが主因。そこを SoT 1 箇所に足すのが本 PR の中心。

## insight ↔ 変更

| insight | 変更 |
|---|---|
| `20260731-verification-must-match-the-scope-of-the-claim.md` | `rules/verify-before-assert.md`: 断定種別に **sweep の完了**（全表記形を含む pattern で grep）を追加。運用に「receipt の scope は主張の scope と一致させる」 |
| `20260731-doc-restatement-across-sections-self-contradicts.md` | 同 file: 断定種別に **同一 doc / 同一 PR 内の他 section が所有する事実**（owner section を開いて突き合わせる）を追加。運用に「再掲を作らないことが最も安い予防」。`self-review-changes` の `conventions` 観点に claim-vs-claim の grep 照合を追加 |
| `20260731-self-audit-of-own-sentences-reproduces-the-blind-spot.md` | 同 file 運用: 「自己点検は自分の文を読み直すのではなく突き合わせ先を開く」（読み直しは元の誤りと同じ盲点を再生産する） |
| `20260731-worktree-isolation-silently-reverts-across-calls.md` / `20260731-worktree-isolation-switches-silently-mid-session.md` | `agents/dev-cycle.md`: 隔離が session 境界で無言に戻ることを明記。絶対 path 必須 / 破壊的 git 操作前の `pwd` + `branch --show-current` 照合 / `Edit` 拒否時は `EnterWorktree(path:)` で入り直す（Bash 迂回禁止） |
| `20260731-verify-the-adr-trigger-before-writing-one.md` | `skills/api-design-review/SKILL.md`: ADR を書く前に発動条件を grep で確定させる 3 step。「Superseded にしない」と書きたくなった時点が中断サイン |
| `20260731-commit-tree-collapse-drops-gpg-signature.md` | `skills/commit-push-branch/SKILL.md`: stacked rebase の step 3 に `-S`（plumbing は `commit.gpgsign` を無視）、step 5 に `%G?` = `G` の検証と `--amend --no-edit` 再署名 |

## routing の判断

- **claim 検証系 3 本を agent ではなく `rules/` に置いた** — promotion order（memory → rules → skill → agent）で安い側。`verify-before-assert.md` は dev-cycle / reviewer / retrospect の共通 SoT なので、1 箇所で全書き手に効く
- **`self-review-changes` の target path を retarget** — insight は `references/` 配下を指していたが、その構造は廃止され 10 観点が単一 SKILL.md に統合済（#36）。新構造の `conventions` 観点に入れた

## 検証

- ja SoT を編集し en mirror は opus subagent が翻訳（`rules/` は mirror なし）
- 4 commit すべて `git log --format='%G?'` = `G`（本 PR で追記した署名検証手順を自分にも適用）
- dotfiles の無関係な未 commit 変更（`claude/settings.json` / `gitconfig` / `starship.toml` / `zshrc`）は worktree 外なので混入なし

## Decisions needed

- `20260731-worktree-isolation-switches-silently-mid-session.md` の提案後半「isolation 切り替え時の通知 or 固定の仕組み」は **Claude Code 本体の挙動**で dotfiles からは対処できない。本 PR は agent 側の緩和のみ。本体側への feedback として扱うかは判断が必要
